### PR TITLE
Guard against concurrent usage of upload tokens

### DIFF
--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -455,7 +455,7 @@ def interpret_b2_error(status, code, message, response_headers, post_params=None
     elif status == 400 and code == "bad_request":
         matcher = UPLOAD_TOKEN_USED_CONCURRENTLY_ERROR_MESSAGE_RE.match(message)
         if matcher is not None:
-            token = m.group('token')
+            token = matcher.group('token')
             return UploadTokenUsedConcurrently(token)
     elif status == 401 and code in ("bad_auth_token", "expired_auth_token"):
         return InvalidAuthToken(message, code)

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -17,7 +17,7 @@ import six
 from .utils import camelcase_to_underscore
 
 UPLOAD_TOKEN_USED_CONCURRENTLY_ERROR_MESSAGE_RE = re.compile(
-    r'more than one upload using auth token (?P<token>.*)'
+    r'^more than one upload using auth token (?P<token>[^)]+)$'
 )
 
 

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -422,7 +422,7 @@ class UploadTokenUsedConcurrently(B2Error):
         self.token = token
 
     def __str__(self):
-        return "More than one concurrent upload using auth token %s" % self.token
+        return "More than one concurrent upload using auth token %s" % (self.token,)
 
 
 def interpret_b2_error(status, code, message, response_headers, post_params=None):

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -416,6 +416,15 @@ class UnsatisfiableRange(B2Error):
         return "The range in the request is outside the size of the file"
 
 
+class UploadTokenUsedConcurrently(B2Error):
+    def __init__(self, token):
+        super(UploadTokenUsedConcurrently, self).__init__()
+        self.token = token
+
+    def __str__(self):
+        return "More than one concurrent upload using auth token %s" % self.token
+
+
 def interpret_b2_error(status, code, message, response_headers, post_params=None):
     post_params = post_params or {}
     if status == 400 and code == "already_hidden":
@@ -438,6 +447,9 @@ def interpret_b2_error(status, code, message, response_headers, post_params=None
         return MissingPart(post_params.get('fileId'))
     elif status == 400 and code == "part_sha1_mismatch":
         return PartSha1Mismatch(post_params.get('fileId'))
+    elif status == 400 and code == "bad_request" and 'more than one upload using auth token' in message:
+        token = message.lstrip('more than one upload using auth token ')
+        return UploadTokenUsedConcurrently(token)
     elif status == 401 and code in ("bad_auth_token", "expired_auth_token"):
         return InvalidAuthToken(message, code)
     elif status == 401:

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -454,7 +454,7 @@ def interpret_b2_error(status, code, message, response_headers, post_params=None
         return PartSha1Mismatch(post_params.get('fileId'))
     elif status == 400 and code == "bad_request":
         matcher = UPLOAD_TOKEN_USED_CONCURRENTLY_ERROR_MESSAGE_RE.match(message)
-        if m:
+        if matcher is not None:
             token = m.group('token')
             return UploadTokenUsedConcurrently(token)
     elif status == 401 and code in ("bad_auth_token", "expired_auth_token"):

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -453,7 +453,7 @@ def interpret_b2_error(status, code, message, response_headers, post_params=None
     elif status == 400 and code == "part_sha1_mismatch":
         return PartSha1Mismatch(post_params.get('fileId'))
     elif status == 400 and code == "bad_request":
-        m = UPLOAD_TOKEN_USED_CONCURRENTLY_ERROR_MESSAGE_RE.match(message)
+        matcher = UPLOAD_TOKEN_USED_CONCURRENTLY_ERROR_MESSAGE_RE.match(message)
         if m:
             token = m.group('token')
             return UploadTokenUsedConcurrently(token)

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -1090,7 +1090,7 @@ class RawSimulator(AbstractRawApi):
             url_match = self.UPLOAD_URL_MATCHER.match(upload_url)
             if url_match is None:
                 raise BadUploadUrl(upload_url)
-            if len(self.upload_errors) != 0:
+            if self.upload_errors:
                 raise self.upload_errors.pop(0)
             bucket_id, upload_id = url_match.groups()
             bucket = self._get_bucket_by_id(bucket_id)

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -1085,7 +1085,9 @@ class RawSimulator(AbstractRawApi):
         self, upload_url, upload_auth_token, file_name, content_length, content_type, content_sha1,
         file_infos, data_stream
     ):
-        with ConcurrentUsedAuthTokenGuard(self.currently_used_auth_tokens, upload_auth_token):
+        with ConcurrentUsedAuthTokenGuard(
+            self.currently_used_auth_tokens[upload_auth_token], upload_auth_token
+        ):
             assert upload_url == upload_auth_token
             url_match = self.UPLOAD_URL_MATCHER.match(upload_url)
             if url_match is None:
@@ -1112,7 +1114,9 @@ class RawSimulator(AbstractRawApi):
     def upload_part(
         self, upload_url, upload_auth_token, part_number, content_length, sha1_sum, input_stream
     ):
-        with ConcurrentUsedAuthTokenGuard(self.currently_used_auth_tokens, upload_auth_token):
+        with ConcurrentUsedAuthTokenGuard(
+            self.currently_used_auth_tokens[upload_auth_token], upload_auth_token
+        ):
             url_match = self.UPLOAD_PART_MATCHER.match(upload_url)
             if url_match is None:
                 raise BadUploadUrl(upload_url)

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -1098,9 +1098,15 @@ class RawSimulator(AbstractRawApi):
             bucket_id, upload_id = url_match.groups()
             bucket = self._get_bucket_by_id(bucket_id)
             response = bucket.upload_file(
-                upload_id, upload_auth_token, file_name, content_length, content_type, content_sha1,
-                file_infos, data_stream
-            )  # yapf: disable
+                upload_id,
+                upload_auth_token,
+                file_name,
+                content_length,
+                content_type,
+                content_sha1,
+                file_infos,
+                data_stream,
+            )
             file_id = response['fileId']
             self.file_id_to_bucket_id[file_id] = bucket_id
         finally:

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -634,6 +634,7 @@ class RawSimulator(AbstractRawApi):
     MAX_DURATION_IN_SECONDS = 86400000
 
     UPLOAD_PART_MATCHER = re.compile('https://upload.example.com/part/([^/]*)')
+    UPLOAD_URL_MATCHER = re.compile(r'https://upload.example.com/([^/]*)/([^/]*)')
     DOWNLOAD_URL_MATCHER = re.compile(
         DOWNLOAD_URL + '(?:' + '|'.join(
             (
@@ -1090,7 +1091,7 @@ class RawSimulator(AbstractRawApi):
 
         try:
             assert upload_url == upload_auth_token
-            url_match = re.match(r'https://upload.example.com/([^/]*)/([^/]*)', upload_url)
+            url_match = self.UPLOAD_URL_MATCHER.match(upload_url)
             if url_match is None:
                 raise BadUploadUrl(upload_url)
             if len(self.upload_errors) != 0:

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -1085,7 +1085,7 @@ class RawSimulator(AbstractRawApi):
         self, upload_url, upload_auth_token, file_name, content_length, content_type, content_sha1,
         file_infos, data_stream
     ):
-        if not self.currently_used_auth_tokens[upload_auth_token].acquire(blocking=False):
+        if not self.currently_used_auth_tokens[upload_auth_token].acquire(False):
             raise UploadTokenUsedConcurrently(upload_auth_token)
 
         try:
@@ -1111,7 +1111,7 @@ class RawSimulator(AbstractRawApi):
     def upload_part(
         self, upload_url, upload_auth_token, part_number, content_length, sha1_sum, input_stream
     ):
-        if not self.currently_used_auth_tokens[upload_auth_token].acquire(blocking=False):
+        if not self.currently_used_auth_tokens[upload_auth_token].acquire(False):
             raise UploadTokenUsedConcurrently(upload_auth_token)
 
         try:

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -11,6 +11,7 @@
 import collections
 import re
 import time
+import threading
 
 import six
 from six.moves import range
@@ -29,6 +30,7 @@ from .exception import (
     NonExistentBucket,
     Unauthorized,
     UnsatisfiableRange,
+    UploadTokenUsedConcurrently,
 )
 from .raw_api import AbstractRawApi, HEX_DIGITS_AT_END, MetadataDirectiveMode, set_token_type, TokenType
 from .utils import b2_url_decode, b2_url_encode
@@ -654,6 +656,10 @@ class RawSimulator(AbstractRawApi):
         # Set of auth tokens that have expired
         self.expired_auth_tokens = set()
 
+        # Map from auth token to a lock that upload procedure acquires
+        # when utilizing the token
+        self.currently_used_auth_tokens = collections.defaultdict(threading.Lock)
+
         # Counter for generating auth tokens.
         self.auth_token_counter = 0
 
@@ -1079,33 +1085,46 @@ class RawSimulator(AbstractRawApi):
         self, upload_url, upload_auth_token, file_name, content_length, content_type, content_sha1,
         file_infos, data_stream
     ):
-        assert upload_url == upload_auth_token
-        url_match = re.match(r'https://upload.example.com/([^/]*)/([^/]*)', upload_url)
-        if url_match is None:
-            raise BadUploadUrl(upload_url)
-        if len(self.upload_errors) != 0:
-            raise self.upload_errors.pop(0)
-        bucket_id, upload_id = url_match.groups()
-        bucket = self._get_bucket_by_id(bucket_id)
-        response = bucket.upload_file(
-            upload_id, upload_auth_token, file_name, content_length, content_type, content_sha1,
-            file_infos, data_stream
-        )  # yapf: disable
-        file_id = response['fileId']
-        self.file_id_to_bucket_id[file_id] = bucket_id
+        if not self.currently_used_auth_tokens[upload_auth_token].acquire(blocking=False):
+            raise UploadTokenUsedConcurrently(upload_auth_token)
+
+        try:
+            assert upload_url == upload_auth_token
+            url_match = re.match(r'https://upload.example.com/([^/]*)/([^/]*)', upload_url)
+            if url_match is None:
+                raise BadUploadUrl(upload_url)
+            if len(self.upload_errors) != 0:
+                raise self.upload_errors.pop(0)
+            bucket_id, upload_id = url_match.groups()
+            bucket = self._get_bucket_by_id(bucket_id)
+            response = bucket.upload_file(
+                upload_id, upload_auth_token, file_name, content_length, content_type, content_sha1,
+                file_infos, data_stream
+            )  # yapf: disable
+            file_id = response['fileId']
+            self.file_id_to_bucket_id[file_id] = bucket_id
+        finally:
+            self.currently_used_auth_tokens[upload_auth_token].release()
         return response
 
     @set_token_type(TokenType.UPLOAD_PART)
     def upload_part(
         self, upload_url, upload_auth_token, part_number, content_length, sha1_sum, input_stream
     ):
-        url_match = self.UPLOAD_PART_MATCHER.match(upload_url)
-        if url_match is None:
-            raise BadUploadUrl(upload_url)
-        file_id = url_match.group(1)
-        bucket_id = self.file_id_to_bucket_id[file_id]
-        bucket = self._get_bucket_by_id(bucket_id)
-        return bucket.upload_part(file_id, part_number, content_length, sha1_sum, input_stream)
+        if not self.currently_used_auth_tokens[upload_auth_token].acquire(blocking=False):
+            raise UploadTokenUsedConcurrently(upload_auth_token)
+
+        try:
+            url_match = self.UPLOAD_PART_MATCHER.match(upload_url)
+            if url_match is None:
+                raise BadUploadUrl(upload_url)
+            file_id = url_match.group(1)
+            bucket_id = self.file_id_to_bucket_id[file_id]
+            bucket = self._get_bucket_by_id(bucket_id)
+            part = bucket.upload_part(file_id, part_number, content_length, sha1_sum, input_stream)
+        finally:
+            self.currently_used_auth_tokens[upload_auth_token].release()
+        return part
 
     def _assert_account_auth(
         self, api_url, account_auth_token, account_id, capability, bucket_id=None, file_name=None

--- a/b2sdk/utils.py
+++ b/b2sdk/utils.py
@@ -367,18 +367,18 @@ class B2TraceMetaAbstract(DefaultTraceAbstractMeta):
 
 
 class ConcurrentUsedAuthTokenGuard(object):
-    def __init__(self, lock_dict, lock_key):
-        self.lock_dict = lock_dict
-        self.lock_key = lock_key
+    def __init__(self, lock, token):
+        self.lock = lock
+        self.token = token
 
     def __enter__(self):
-        if not self.lock_dict[self.lock_key].acquire(False):
+        if not self.lock.acquire(False):
             from b2sdk.exception import UploadTokenUsedConcurrently
-            raise UploadTokenUsedConcurrently(self.lock_key)
+            raise UploadTokenUsedConcurrently(self.token)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            self.lock_dict[self.lock_key].release()
+            self.lock.release()
         except RuntimeError:
             # guard against releasing a non-acquired lock
             pass


### PR DESCRIPTION
* Guards simulator against Backblaze/b2-sdk-python#79
* Raises `UploadTokenUsedConcurrently` in case same error occurs