### PR TITLE
Method to compare credentials in account_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Add `check_current_credentials` method to AccountInfo.
+
+### Removed
+* Removed `get_bucket_name_or_none_from_allowed` method from cache classes
+
 ## [1.3.0] - 2021-01-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* Add `check_current_credentials` method to AccountInfo.
+* Add `check_current_credentials` method to `AccountInfo`.
 
 ## [1.3.0] - 2021-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Add `check_current_credentials` method to AccountInfo.
 
-### Removed
-* Removed `get_bucket_name_or_none_from_allowed` method from cache classes
-
 ## [1.3.0] - 2021-01-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* Add `check_current_credentials` method to `AccountInfo`.
+* Add `is_same_key` method to `AccountInfo`.
+
+### Fixed
+* Remove unnecessary cache clearing when reauthorizing with the same key
 
 ## [1.3.0] - 2021-01-13
 

--- a/b2sdk/account_info/abstract.py
+++ b/b2sdk/account_info/abstract.py
@@ -100,20 +100,16 @@ class AbstractAccountInfo(metaclass=B2TraceMetaAbstract):
         :param str bucket_id: a bucket ID
         """
 
-    def check_current_credentials(self, key_id, key, realm):
+    def is_same_key(self, application_key_id, realm):
         """
-        Check whether provided key_id, key and realm are the credentials cached at the moment.
+        Check whether cached application key is the same as the one provided.
 
-        :param str key_id: application key ID used to authenticate
-        :param str key: application key
+        :param str application_key_id: application key ID
         :param str realm: authorization realm
         :rtype: bool
         """
         try:
-            return (
-                self.get_application_key() == key and self.get_application_key_id() == key_id and
-                self.get_realm() == realm
-            )
+            return self.get_application_key_id() == application_key_id and self.get_realm() == realm
         except exception.MissingAccountData:
             return False
 

--- a/b2sdk/account_info/abstract.py
+++ b/b2sdk/account_info/abstract.py
@@ -10,6 +10,7 @@
 
 from abc import abstractmethod
 
+from . import exception
 from b2sdk.raw_api import ALL_CAPABILITIES
 from b2sdk.utils import B2TraceMetaAbstract, limit_trace_arguments
 
@@ -98,6 +99,20 @@ class AbstractAccountInfo(metaclass=B2TraceMetaAbstract):
 
         :param str bucket_id: a bucket ID
         """
+
+    def check_current_credentials(self, key_id, key, realm):
+        """
+        Checks whether provided key_id, key and realm are the credentials cached at the moment
+        :rtype: bool
+        """
+        try:
+            return (
+                    self.get_application_key() == key and
+                    self.get_application_key_id() == key_id and
+                    self.get_realm() == realm
+            )
+        except exception.MissingAccountData:
+            return False
 
     @abstractmethod
     def get_account_id(self):

--- a/b2sdk/account_info/abstract.py
+++ b/b2sdk/account_info/abstract.py
@@ -102,14 +102,17 @@ class AbstractAccountInfo(metaclass=B2TraceMetaAbstract):
 
     def check_current_credentials(self, key_id, key, realm):
         """
-        Checks whether provided key_id, key and realm are the credentials cached at the moment
+        Check whether provided key_id, key and realm are the credentials cached at the moment.
+
+        :param str key_id: application key ID used to authenticate
+        :param str key: application key
+        :param str realm: authorization realm
         :rtype: bool
         """
         try:
             return (
-                    self.get_application_key() == key and
-                    self.get_application_key_id() == key_id and
-                    self.get_realm() == realm
+                self.get_application_key() == key and self.get_application_key_id() == key_id and
+                self.get_realm() == realm
             )
         except exception.MissingAccountData:
             return False

--- a/b2sdk/cache.py
+++ b/b2sdk/cache.py
@@ -20,10 +20,6 @@ class AbstractCache(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_bucket_name_or_none_from_allowed(self):
-        pass
-
-    @abstractmethod
     def save_bucket(self, bucket):
         pass
 
@@ -41,9 +37,6 @@ class DummyCache(AbstractCache):
     """
 
     def get_bucket_id_or_none_from_bucket_name(self, name):
-        return None
-
-    def get_bucket_name_or_none_from_allowed(self):
         return None
 
     def save_bucket(self, bucket):
@@ -65,9 +58,6 @@ class InMemoryCache(AbstractCache):
     def get_bucket_id_or_none_from_bucket_name(self, name):
         return self.name_id_map.get(name)
 
-    def get_bucket_name_or_none_from_allowed(self):
-        return self.bucket_name
-
     def save_bucket(self, bucket):
         self.name_id_map[bucket.name] = bucket.id_
 
@@ -85,9 +75,6 @@ class AuthInfoCache(AbstractCache):
 
     def get_bucket_id_or_none_from_bucket_name(self, name):
         return self.info.get_bucket_id_or_none_from_bucket_name(name)
-
-    def get_bucket_name_or_none_from_allowed(self):
-        return self.info.get_bucket_name_or_none_from_allowed()
 
     def save_bucket(self, bucket):
         self.info.save_bucket(bucket)

--- a/b2sdk/cache.py
+++ b/b2sdk/cache.py
@@ -20,6 +20,10 @@ class AbstractCache(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_bucket_name_or_none_from_allowed(self):
+        pass
+
+    @abstractmethod
     def save_bucket(self, bucket):
         pass
 
@@ -37,6 +41,9 @@ class DummyCache(AbstractCache):
     """
 
     def get_bucket_id_or_none_from_bucket_name(self, name):
+        return None
+
+    def get_bucket_name_or_none_from_allowed(self):
         return None
 
     def save_bucket(self, bucket):
@@ -58,6 +65,9 @@ class InMemoryCache(AbstractCache):
     def get_bucket_id_or_none_from_bucket_name(self, name):
         return self.name_id_map.get(name)
 
+    def get_bucket_name_or_none_from_allowed(self):
+        return self.bucket_name
+
     def save_bucket(self, bucket):
         self.name_id_map[bucket.name] = bucket.id_
 
@@ -75,6 +85,9 @@ class AuthInfoCache(AbstractCache):
 
     def get_bucket_id_or_none_from_bucket_name(self, name):
         return self.info.get_bucket_id_or_none_from_bucket_name(name)
+
+    def get_bucket_name_or_none_from_allowed(self):
+        return self.info.get_bucket_name_or_none_from_allowed()
 
     def save_bucket(self, bucket):
         self.info.save_bucket(bucket)

--- a/b2sdk/session.py
+++ b/b2sdk/session.py
@@ -100,12 +100,7 @@ class B2Session(object):
         :param str application_key: user's :term:`application key`
         """
         # Clean up any previous account info if it was for a different account.
-        try:
-            old_account_id = self.account_info.get_account_id()
-            old_realm = self.account_info.get_realm()
-            if application_key_id != old_account_id or realm != old_realm:
-                self.cache.clear()
-        except MissingAccountData:
+        if not self.account_info.is_same_key(application_key_id, realm):
             self.cache.clear()
 
         # Authorize

--- a/test/unit/v0/test_account_info.py
+++ b/test/unit/v0/test_account_info.py
@@ -93,7 +93,7 @@ class AccountInfoBase(metaclass=ABCMeta):
             account_info.get_minimum_part_size()
         with self.assertRaises(MissingAccountData):
             account_info.get_application_key_id()
-        self.assertFalse(account_info.check_current_credentials('key_id', 'app_key', 'realm'))
+        self.assertFalse(account_info.is_same_key('key_id', 'realm'))
 
     def test_set_auth_data_compatibility(self):
         account_info = self._make_info()
@@ -204,8 +204,8 @@ class AccountInfoBase(metaclass=ABCMeta):
             self.assertEqual('key_id', info2.get_application_key_id())
             self.assertEqual('realm', info2.get_realm())
             self.assertEqual(100, info2.get_minimum_part_size())
-            self.assertTrue(info2.check_current_credentials('key_id', 'app_key', 'realm'))
-            self.assertFalse(info2.check_current_credentials('key_id', 'app_key', 'another_realm'))
+            self.assertTrue(info2.is_same_key('key_id', 'realm'))
+            self.assertFalse(info2.is_same_key('key_id', 'another_realm'))
 
     def test_account_info_same_object(self):
         self._test_account_info(check_persistence=False)

--- a/test/unit/v0/test_account_info.py
+++ b/test/unit/v0/test_account_info.py
@@ -66,7 +66,14 @@ class AccountInfoBase(metaclass=ABCMeta):
     def test_clear(self):
         account_info = self._make_info()
         account_info.set_auth_data(
-            'account_id', 'account_auth', 'api_url', 'download_url', 100, 'app_key', 'realm'
+            'account_id',
+            'account_auth',
+            'api_url',
+            'download_url',
+            100,
+            'app_key',
+            'realm',
+            application_key_id='key_id',
         )
         account_info.clear()
 
@@ -84,6 +91,9 @@ class AccountInfoBase(metaclass=ABCMeta):
             account_info.get_realm()
         with self.assertRaises(MissingAccountData):
             account_info.get_minimum_part_size()
+        with self.assertRaises(MissingAccountData):
+            account_info.get_application_key_id()
+        self.assertFalse(account_info.check_current_credentials('key_id', 'app_key', 'realm'))
 
     def test_set_auth_data_compatibility(self):
         account_info = self._make_info()
@@ -172,7 +182,14 @@ class AccountInfoBase(metaclass=ABCMeta):
     def _test_account_info(self, check_persistence):
         account_info = self._make_info()
         account_info.set_auth_data(
-            'account_id', 'account_auth', 'api_url', 'download_url', 100, 'app_key', 'realm'
+            'account_id',
+            'account_auth',
+            'api_url',
+            'download_url',
+            100,
+            'app_key',
+            'realm',
+            application_key_id='key_id'
         )
 
         object_instances = [account_info]
@@ -184,8 +201,11 @@ class AccountInfoBase(metaclass=ABCMeta):
             self.assertEqual('account_auth', info2.get_account_auth_token())
             self.assertEqual('api_url', info2.get_api_url())
             self.assertEqual('app_key', info2.get_application_key())
+            self.assertEqual('key_id', info2.get_application_key_id())
             self.assertEqual('realm', info2.get_realm())
             self.assertEqual(100, info2.get_minimum_part_size())
+            self.assertTrue(info2.check_current_credentials('key_id', 'app_key', 'realm'))
+            self.assertFalse(info2.check_current_credentials('key_id', 'app_key', 'another_realm'))
 
     def test_account_info_same_object(self):
         self._test_account_info(check_persistence=False)

--- a/test/unit/v0/test_api.py
+++ b/test/unit/v0/test_api.py
@@ -7,6 +7,7 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+from unittest import mock
 
 from .test_base import TestBase
 
@@ -109,6 +110,15 @@ class TestApi(TestBase):
         self.api.authorize_account('production', key['applicationKeyId'], key['applicationKey'])
         with self.assertRaises(RestrictedBucket):
             self.api.list_buckets()
+
+    def test_authorize_account_cache_reused(self):
+        with mock.patch.object(self.cache, 'clear') as clear_mock:
+            # the first time we authorize the cache is supposed to be cleaned
+            self._authorize_account()
+            clear_mock.assert_called_once()
+            # the second time it's not supposed to be called
+            self._authorize_account()
+            clear_mock.assert_called_once()
 
     def _authorize_account(self):
         self.api.authorize_account('production', self.application_key_id, self.master_key)

--- a/test/unit/v0/test_api.py
+++ b/test/unit/v0/test_api.py
@@ -115,10 +115,10 @@ class TestApi(TestBase):
         with mock.patch.object(self.cache, 'clear') as clear_mock:
             # the first time we authorize the cache is supposed to be cleaned
             self._authorize_account()
-            clear_mock.assert_called_once()
+            clear_mock.assert_called_once_with()
             # the second time it's not supposed to be called
             self._authorize_account()
-            clear_mock.assert_called_once()
+            clear_mock.assert_called_once_with()
 
     def _authorize_account(self):
         self.api.authorize_account('production', self.application_key_id, self.master_key)

--- a/test/unit/v1/test_account_info.py
+++ b/test/unit/v1/test_account_info.py
@@ -62,7 +62,14 @@ class AccountInfoBase(metaclass=ABCMeta):
     def test_clear(self):
         account_info = self._make_info()
         account_info.set_auth_data(
-            'account_id', 'account_auth', 'api_url', 'download_url', 100, 'app_key', 'realm'
+            'account_id',
+            'account_auth',
+            'api_url',
+            'download_url',
+            100,
+            'app_key',
+            'realm',
+            application_key_id='key_id',
         )
         account_info.clear()
 
@@ -80,6 +87,9 @@ class AccountInfoBase(metaclass=ABCMeta):
             account_info.get_realm()
         with self.assertRaises(MissingAccountData):
             account_info.get_minimum_part_size()
+        with self.assertRaises(MissingAccountData):
+            account_info.get_application_key_id()
+        self.assertFalse(account_info.check_current_credentials('key_id', 'app_key', 'realm'))
 
     def test_set_auth_data_compatibility(self):
         account_info = self._make_info()
@@ -168,7 +178,14 @@ class AccountInfoBase(metaclass=ABCMeta):
     def _test_account_info(self, check_persistence):
         account_info = self._make_info()
         account_info.set_auth_data(
-            'account_id', 'account_auth', 'api_url', 'download_url', 100, 'app_key', 'realm'
+            'account_id',
+            'account_auth',
+            'api_url',
+            'download_url',
+            100,
+            'app_key',
+            'realm',
+            application_key_id='key_id'
         )
 
         object_instances = [account_info]
@@ -180,8 +197,11 @@ class AccountInfoBase(metaclass=ABCMeta):
             self.assertEqual('account_auth', info2.get_account_auth_token())
             self.assertEqual('api_url', info2.get_api_url())
             self.assertEqual('app_key', info2.get_application_key())
+            self.assertEqual('key_id', info2.get_application_key_id())
             self.assertEqual('realm', info2.get_realm())
             self.assertEqual(100, info2.get_minimum_part_size())
+            self.assertTrue(info2.check_current_credentials('key_id', 'app_key', 'realm'))
+            self.assertFalse(info2.check_current_credentials('key_id', 'app_key', 'another_realm'))
 
     def test_account_info_same_object(self):
         self._test_account_info(check_persistence=False)

--- a/test/unit/v1/test_account_info.py
+++ b/test/unit/v1/test_account_info.py
@@ -89,7 +89,7 @@ class AccountInfoBase(metaclass=ABCMeta):
             account_info.get_minimum_part_size()
         with self.assertRaises(MissingAccountData):
             account_info.get_application_key_id()
-        self.assertFalse(account_info.check_current_credentials('key_id', 'app_key', 'realm'))
+        self.assertFalse(account_info.is_same_key('key_id', 'realm'))
 
     def test_set_auth_data_compatibility(self):
         account_info = self._make_info()
@@ -200,8 +200,8 @@ class AccountInfoBase(metaclass=ABCMeta):
             self.assertEqual('key_id', info2.get_application_key_id())
             self.assertEqual('realm', info2.get_realm())
             self.assertEqual(100, info2.get_minimum_part_size())
-            self.assertTrue(info2.check_current_credentials('key_id', 'app_key', 'realm'))
-            self.assertFalse(info2.check_current_credentials('key_id', 'app_key', 'another_realm'))
+            self.assertTrue(info2.is_same_key('key_id', 'realm'))
+            self.assertFalse(info2.is_same_key('key_id', 'another_realm'))
 
     def test_account_info_same_object(self):
         self._test_account_info(check_persistence=False)

--- a/test/unit/v1/test_api.py
+++ b/test/unit/v1/test_api.py
@@ -7,6 +7,7 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+from unittest import mock
 
 from .test_base import TestBase
 
@@ -98,6 +99,15 @@ class TestApi(TestBase):
         self.api.authorize_account('production', key['applicationKeyId'], key['applicationKey'])
         with self.assertRaises(RestrictedBucket):
             self.api.list_buckets()
+
+    def test_authorize_account_cache_reused(self):
+        with mock.patch.object(self.cache, 'clear') as clear_mock:
+            # the first time we authorize the cache is supposed to be cleaned
+            self._authorize_account()
+            clear_mock.assert_called_once()
+            # the second time it's not supposed to be called
+            self._authorize_account()
+            clear_mock.assert_called_once()
 
     def _authorize_account(self):
         self.api.authorize_account('production', self.application_key_id, self.master_key)

--- a/test/unit/v1/test_api.py
+++ b/test/unit/v1/test_api.py
@@ -104,10 +104,10 @@ class TestApi(TestBase):
         with mock.patch.object(self.cache, 'clear') as clear_mock:
             # the first time we authorize the cache is supposed to be cleaned
             self._authorize_account()
-            clear_mock.assert_called_once()
+            clear_mock.assert_called_once_with()
             # the second time it's not supposed to be called
             self._authorize_account()
-            clear_mock.assert_called_once()
+            clear_mock.assert_called_once_with()
 
     def _authorize_account(self):
         self.api.authorize_account('production', self.application_key_id, self.master_key)


### PR DESCRIPTION
Method needed for checking whether new authorization data and cached authorization data match or not. Needed for authorizing via environment variables. I did not write any tests because I wasn't sure if it's a good idea to put it here - maybe it should be left in CLI.