### PR TITLE
Fix FileVersion._get_upload_headers when key secret is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix download integration tests on non-production environments
 * Add `B2_DEBUG_HTTP` env variable to enable network-level test debugging
 * Disable changelog validation temporarily
+* Fix `FileVersion._get_upload_headers` when encryption key is `None`
 
 ## [1.17.2] - 2022-06-24
 
@@ -21,9 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fix importing scan module
-* Fix `FileVersion._get_upload_headers` when encryption key is `None`
 
-## [1.17.0] - 2022-06-23
+## [1.17.0] - 2022-06-23 [YANKED]
 
 As in version 1.16.0, the replication API may still be unstable, however
 no backward-incompatible changes are planned at this point.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fix importing scan module
+* Fix `FileVersion._get_upload_headers` when encryption key is `None`
 
-## [1.17.0] - 2022-06-23 [YANKED]
+## [1.17.0] - 2022-06-23
 
 As in version 1.16.0, the replication API may still be unstable, however
 no backward-incompatible changes are planned at this point.

--- a/b2sdk/encryption/types.py
+++ b/b2sdk/encryption/types.py
@@ -19,7 +19,7 @@ class EncryptionAlgorithm(Enum):
 
     def get_length(self) -> int:
         if self is EncryptionAlgorithm.AES256:
-            return 256
+            return int(256 / 8)
 
         raise NotImplementedError()
 

--- a/b2sdk/encryption/types.py
+++ b/b2sdk/encryption/types.py
@@ -17,6 +17,12 @@ class EncryptionAlgorithm(Enum):
 
     AES256 = 'AES256'
 
+    def get_length(self) -> int:
+        if self is EncryptionAlgorithm.AES256:
+            return 256
+
+        raise NotImplementedError()
+
 
 @unique
 class EncryptionMode(Enum):

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -318,7 +318,7 @@ class FileVersion(BaseFileVersion):
         sse = self.server_side_encryption
         if sse and sse.key and sse.key.secret is None:
             sse = deepcopy(sse)
-            sse.key.secret = b'secret'
+            sse.key.secret = b'*' * sse.algorithm.get_length()
 
         headers = self.api.raw_api.get_upload_file_headers(
             upload_auth_token=self.api.account_info.get_account_auth_token(),

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -10,6 +10,7 @@
 
 from typing import Dict, Optional, Union, Tuple, TYPE_CHECKING
 import re
+from copy import deepcopy
 
 from .encryption.setting import EncryptionSetting, EncryptionSettingFactory
 from .replication.types import ReplicationStatus
@@ -310,6 +311,15 @@ class FileVersion(BaseFileVersion):
         key and value. This implementation is in par with ADVANCED_HEADERS_LIMIT
         and is reasonable only for `has_large_header` method
         """
+
+        # sometimes secret is not available, but we want to calculate headers
+        # size anyway; to bypass this, we use a fake encryption setting
+        # with a fake key
+        sse = self.server_side_encryption
+        if sse and sse.key and sse.key.secret is None:
+            sse = deepcopy(sse)
+            sse.key.secret = b'secret'
+
         headers = self.api.raw_api.get_upload_file_headers(
             upload_auth_token=self.api.account_info.get_account_auth_token(),
             file_name=self.file_name,
@@ -317,7 +327,7 @@ class FileVersion(BaseFileVersion):
             content_type=self.content_type,
             content_sha1=self.content_sha1,
             file_infos=self.file_info,
-            server_side_encryption=self.server_side_encryption,
+            server_side_encryption=sse,
             file_retention=self.file_retention,
             legal_hold=self.legal_hold,
         )


### PR DESCRIPTION
When reading `FileVersion`s from bucket, the SSE-C encryption secret is empty, so `_get_upload_headers` fails to generate encryption-related header. We add a fake key in such case, because we don't really bother about the key itself - it's only needed for calculating headers size (in order to detect large file headers).