### PR TITLE
Fix `B2Api.get_key()` and `RawSimulator.delete_key()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fix: replace `ReplicationScanResult.source_has_sse_c_enabled` with `source_encryption_mode`
+* Fix `B2Api.get_key()` and `RawSimulator.delete_key()`
 
 ## [1.17.3] - 2022-07-15
 

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -1400,6 +1400,9 @@ class RawSimulator(AbstractRawApi):
                 'application key does not exist: %s' % (application_key_id,),
                 'bad_request',
             )
+        self.all_application_keys = [
+            key for key in self.all_application_keys if key.application_key_id != application_key_id
+        ]
         return key_sim.as_key()
 
     def finish_large_file(self, api_url, account_auth_token, file_id, part_sha1_array):

--- a/b2sdk/v1/api.py
+++ b/b2sdk/v1/api.py
@@ -204,3 +204,7 @@ class B2Api(v2.B2Api):
 
     def delete_key(self, application_key_id):
         return super().delete_key_by_id(application_key_id).as_dict()
+
+    def get_key(self, key_id: str) -> Optional[dict]:
+        keys = self.list_keys(start_application_key_id=key_id)['keys']
+        return next((key for key in keys if key['applicationKeyId'] == key_id), None)

--- a/test/unit/api/test_api.py
+++ b/test/unit/api/test_api.py
@@ -480,3 +480,29 @@ class TestApi:
             'appKeyId9',
         ]
         assert isinstance(keys[0], ApplicationKey)
+
+    @pytest.mark.apiver(from_ver=2)
+    def test_get_key(self):
+        self._authorize_account()
+        key = self.api.create_key(['readFiles'], 'testkey')
+
+        assert self.api.get_key(key.id_) is not None
+
+        self.api.delete_key(key)
+        assert self.api.get_key(key.id_) is None
+
+        assert self.api.get_key('non-existent') is None
+
+    @pytest.mark.apiver(to_ver=1)
+    def test_get_key_old(self):
+        self._authorize_account()
+
+        key = self.api.create_key(['readFiles'], 'testkey')
+        key_id = key['applicationKeyId']
+
+        assert self.api.get_key(key_id) is not None
+
+        self.api.delete_key(key_id)
+        assert self.api.get_key(key_id) is None
+
+        assert self.api.get_key('non-existent') is None

--- a/test/unit/api/test_api.py
+++ b/test/unit/api/test_api.py
@@ -481,28 +481,21 @@ class TestApi:
         ]
         assert isinstance(keys[0], ApplicationKey)
 
-    @pytest.mark.apiver(from_ver=2)
     def test_get_key(self):
         self._authorize_account()
         key = self.api.create_key(['readFiles'], 'testkey')
 
-        assert self.api.get_key(key.id_) is not None
-
-        self.api.delete_key(key)
-        assert self.api.get_key(key.id_) is None
-
-        assert self.api.get_key('non-existent') is None
-
-    @pytest.mark.apiver(to_ver=1)
-    def test_get_key_old(self):
-        self._authorize_account()
-
-        key = self.api.create_key(['readFiles'], 'testkey')
-        key_id = key['applicationKeyId']
+        if apiver_deps.V <= 1:
+            key_id = key['applicationKeyId']
+        else:
+            key_id = key.id_
 
         assert self.api.get_key(key_id) is not None
 
-        self.api.delete_key(key_id)
-        assert self.api.get_key(key_id) is None
+        if apiver_deps.V <= 1:
+            self.api.delete_key(key_id)
+        else:
+            self.api.delete_key(key)
 
+        assert self.api.get_key(key_id) is None
         assert self.api.get_key('non-existent') is None


### PR DESCRIPTION
`B2Api.get_key()` gives you a wrong key if `key_id` does not exist. B2 api docs don't say what happens if you give non-existent `startApplicationKeyId`: https://www.backblaze.com/b2/docs/b2_list_keys.html - in fact it returns some _next_ key.

`RawSimulator.delete_key()` was deleting key from internal key->value mapping, but not from `self.all_application_keys`.