### PR TITLE
Add `large_file_sha1` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Authorizing a key for a single bucket ensures that this bucket is cached
 * `Bucket.ls` operation supports wildcard matching strings
+* Add `large_file_sha1` support
 
 ### Infrastructure
 * Additional tests for listing files/versions

--- a/b2sdk/_v3/__init__.py
+++ b/b2sdk/_v3/__init__.py
@@ -235,5 +235,6 @@ from b2sdk.cache import AuthInfoCache
 from b2sdk.cache import DummyCache
 from b2sdk.cache import InMemoryCache
 from b2sdk.http_constants import SRC_LAST_MODIFIED_MILLIS
+from b2sdk.http_constants import LARGE_FILE_SHA1
 from b2sdk.session import B2Session
 from b2sdk.utils.thread_pool import ThreadPoolMixin

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -622,6 +622,7 @@ class Bucket(metaclass=B2TraceMeta):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         """
         Creates a new file in this bucket using an iterable (list, tuple etc) of remote or local sources.
@@ -648,6 +649,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self._create_file(
             self.api.services.emerger.emerge,
@@ -663,6 +665,7 @@ class Bucket(metaclass=B2TraceMeta):
             legal_hold=legal_hold,
             min_part_size=min_part_size,
             max_part_size=max_part_size,
+            large_file_sha1=large_file_sha1,
         )
 
     def create_file_stream(
@@ -679,6 +682,7 @@ class Bucket(metaclass=B2TraceMeta):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         """
         Creates a new file in this bucket using a stream of multiple remote or local sources.
@@ -707,6 +711,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self._create_file(
             self.api.services.emerger.emerge_stream,
@@ -722,6 +727,7 @@ class Bucket(metaclass=B2TraceMeta):
             legal_hold=legal_hold,
             min_part_size=min_part_size,
             max_part_size=max_part_size,
+            large_file_sha1=large_file_sha1,
         )
 
     def _create_file(
@@ -739,6 +745,7 @@ class Bucket(metaclass=B2TraceMeta):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         validate_b2_file_name(file_name)
         progress_listener = progress_listener or DoNothingProgressListener()
@@ -757,6 +764,7 @@ class Bucket(metaclass=B2TraceMeta):
             legal_hold=legal_hold,
             min_part_size=min_part_size,
             max_part_size=max_part_size,
+            large_file_sha1=large_file_sha1,
         )
 
     def concatenate(
@@ -773,6 +781,7 @@ class Bucket(metaclass=B2TraceMeta):
         legal_hold: Optional[LegalHold] = None,
         min_part_size=None,
         max_part_size=None,
+        large_file_sha1=None,
     ):
         """
         Creates a new file in this bucket by concatenating multiple remote or local sources.
@@ -796,9 +805,10 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self.create_file(
-            WriteIntent.wrap_sources_iterator(outbound_sources),
+            list(WriteIntent.wrap_sources_iterator(outbound_sources)),
             file_name,
             content_type=content_type,
             file_info=file_info,
@@ -810,6 +820,7 @@ class Bucket(metaclass=B2TraceMeta):
             legal_hold=legal_hold,
             min_part_size=min_part_size,
             max_part_size=max_part_size,
+            large_file_sha1=large_file_sha1,
         )
 
     def concatenate_stream(
@@ -824,6 +835,7 @@ class Bucket(metaclass=B2TraceMeta):
         encryption: Optional[EncryptionSetting] = None,
         file_retention: Optional[FileRetentionSetting] = None,
         legal_hold: Optional[LegalHold] = None,
+        large_file_sha1: Optional[str] = None,
     ):
         """
         Creates a new file in this bucket by concatenating stream of multiple remote or local sources.
@@ -846,6 +858,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param b2sdk.v2.EncryptionSetting encryption: encryption setting (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
         :param bool legal_hold: legal hold setting
+        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self.create_file_stream(
             WriteIntent.wrap_sources_iterator(outbound_sources_iterator),
@@ -858,6 +871,7 @@ class Bucket(metaclass=B2TraceMeta):
             encryption=encryption,
             file_retention=file_retention,
             legal_hold=legal_hold,
+            large_file_sha1=large_file_sha1,
         )
 
     def get_download_url(self, filename):

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -631,7 +631,7 @@ class Bucket(metaclass=B2TraceMeta):
         For more information and usage examples please see :ref:`Advanced usage patterns <AdvancedUsagePatterns>`.
 
         :param list[b2sdk.v2.WriteIntent] write_intents: list of write intents (remote or local sources)
-        :param str new_file_name: file name of the new file
+        :param str file_name: file name of the new file
         :param str,None content_type: content_type for the new file, if ``None`` content_type would be
                         automatically determined or it may be copied if it resolves
                         as single part remote source copy
@@ -649,7 +649,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
-        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
+        :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self._create_file(
             self.api.services.emerger.emerge,
@@ -692,7 +692,7 @@ class Bucket(metaclass=B2TraceMeta):
 
         :param iterator[b2sdk.v2.WriteIntent] write_intents_iterator: iterator of write intents which
                         are sorted ascending by ``destination_offset``
-        :param str new_file_name: file name of the new file
+        :param str file_name: file name of the new file
         :param str,None content_type: content_type for the new file, if ``None`` content_type would be
                         automatically determined or it may be copied if it resolves
                         as single part remote source copy
@@ -711,7 +711,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
-        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
+        :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self._create_file(
             self.api.services.emerger.emerge_stream,
@@ -787,7 +787,7 @@ class Bucket(metaclass=B2TraceMeta):
         Creates a new file in this bucket by concatenating multiple remote or local sources.
 
         :param list[b2sdk.v2.OutboundTransferSource] outbound_sources: list of outbound sources (remote or local)
-        :param str new_file_name: file name of the new file
+        :param str file_name: file name of the new file
         :param str,None content_type: content_type for the new file, if ``None`` content_type would be
                         automatically determined from file name or it may be copied if it resolves
                         as single part remote source copy
@@ -805,7 +805,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param bool legal_hold: legal hold setting
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
-        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
+        :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self.create_file(
             list(WriteIntent.wrap_sources_iterator(outbound_sources)),
@@ -841,7 +841,7 @@ class Bucket(metaclass=B2TraceMeta):
         Creates a new file in this bucket by concatenating stream of multiple remote or local sources.
 
         :param iterator[b2sdk.v2.OutboundTransferSource] outbound_sources_iterator: iterator of outbound sources
-        :param str new_file_name: file name of the new file
+        :param str file_name: file name of the new file
         :param str,None content_type: content_type for the new file, if ``None`` content_type would be
                         automatically determined or it may be copied if it resolves
                         as single part remote source copy
@@ -858,7 +858,7 @@ class Bucket(metaclass=B2TraceMeta):
         :param b2sdk.v2.EncryptionSetting encryption: encryption setting (``None`` if unknown)
         :param b2sdk.v2.FileRetentionSetting file_retention: file retention setting
         :param bool legal_hold: legal hold setting
-        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
+        :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         return self.create_file_stream(
             WriteIntent.wrap_sources_iterator(outbound_sources_iterator),

--- a/b2sdk/http_constants.py
+++ b/b2sdk/http_constants.py
@@ -16,6 +16,7 @@ FILE_INFO_HEADER_PREFIX_LOWER = FILE_INFO_HEADER_PREFIX.lower()
 
 # Standard names for file info entries
 SRC_LAST_MODIFIED_MILLIS = 'src_last_modified_millis'
+LARGE_FILE_SHA1 = 'large_file_sha1'
 
 # Special X-Bz-Content-Sha1 value to verify checksum at the end
 HEX_DIGITS_AT_END = 'hex_digits_at_end'

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -671,7 +671,7 @@ class BucketSimulator:
         return self.file_id_to_file[file_id].as_upload_result(account_auth_token)
 
     def get_file_info_by_name(self, account_auth_token, file_name):
-        for ((name, id), file) in sorted(self.file_name_and_id_to_file.items()):
+        for ((name, id), file) in self.file_name_and_id_to_file.items():
             if file_name == name:
                 return file.as_download_headers(account_auth_token_or_none=account_auth_token)
         raise FileNotPresent(file_id_or_name=file_name, bucket_name=self.bucket_name)

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -671,7 +671,7 @@ class BucketSimulator:
         return self.file_id_to_file[file_id].as_upload_result(account_auth_token)
 
     def get_file_info_by_name(self, account_auth_token, file_name):
-        for ((name, id), file) in self.file_name_and_id_to_file.items():
+        for ((name, id), file) in sorted(self.file_name_and_id_to_file.items()):
             if file_name == name:
                 return file.as_download_headers(account_auth_token_or_none=account_auth_token)
         raise FileNotPresent(file_id_or_name=file_name, bucket_name=self.bucket_name)

--- a/b2sdk/transfer/emerge/emerger.py
+++ b/b2sdk/transfer/emerge/emerger.py
@@ -86,7 +86,7 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         """
         Create a new file (object in the cloud, really) from an iterable (list, tuple etc) of write intents.
 
-        :param str bucket_id: a buckeID
+        :param str bucket_id: a bucket ID
         :param write_intents: write intents to process to create a file
         :type write_intents: List[b2sdk.v2.WriteIntent]
         :param str file_name: the file name of the new B2 file

--- a/b2sdk/transfer/emerge/emerger.py
+++ b/b2sdk/transfer/emerge/emerger.py
@@ -42,8 +42,9 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         self.services = services
         self.emerge_executor = EmergeExecutor(services)
 
-    @staticmethod
+    @classmethod
     def _get_updated_file_info_with_large_file_sha1(
+        cls,
         file_info: Optional[Dict[str, str]],
         write_intents: List[WriteIntent],
         emerge_plan: EmergePlan,
@@ -95,7 +96,7 @@ class Emerger(metaclass=B2TraceMetaAbstract):
 
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
-        :param str,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
+        :param Sha1HexDigest,None large_file_sha1: SHA-1 hash of the result file or ``None`` if unknown
         """
         # WARNING: time spent trying to extract common parts of emerge() and emerge_stream()
         # into a separate method: 20min. You can try it too, but please increment the timer honestly.
@@ -163,7 +164,7 @@ class Emerger(metaclass=B2TraceMetaAbstract):
 
         :param int min_part_size: lower limit of part size for the transfer planner, in bytes
         :param int max_part_size: upper limit of part size for the transfer planner, in bytes
-        :param str,None large_file_sha1: result file SHA1 hash or ``None`` if not known
+        :param Sha1HexDigest,None large_file_sha1: result file SHA1 hash or ``None`` if not known
         """
         planner = self.get_emerge_planner(
             min_part_size=min_part_size,

--- a/b2sdk/transfer/emerge/executor.py
+++ b/b2sdk/transfer/emerge/executor.py
@@ -8,6 +8,7 @@
 #
 ######################################################################
 
+import logging
 import threading
 
 from abc import ABCMeta, abstractmethod
@@ -16,10 +17,13 @@ from typing import Optional
 from b2sdk.encryption.setting import EncryptionSetting
 from b2sdk.exception import MaxFileSizeExceeded
 from b2sdk.file_lock import FileRetentionSetting, LegalHold, NO_RETENTION_FILE_SETTING
+from b2sdk.http_constants import LARGE_FILE_SHA1
 from b2sdk.transfer.outbound.large_file_upload_state import LargeFileUploadState
 from b2sdk.transfer.outbound.upload_source import UploadSourceStream
 
 AUTO_CONTENT_TYPE = 'b2/x-auto'
+
+logger = logging.getLogger(__name__)
 
 
 class EmergeExecutor:
@@ -345,6 +349,10 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
                 best_match_parts_len = finished_parts_len
         return best_match_file, best_match_parts
 
+    @staticmethod
+    def _get_file_info_without_large_file_sha1(file_info):
+        return {k: v for k, v in file_info.items() if k != LARGE_FILE_SHA1}
+
     def _match_unfinished_file_if_possible(
         self,
         bucket_id,
@@ -363,29 +371,53 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         This is only possible if the application key being used allows ``listFiles`` access.
         """
         file_retention = file_retention or NO_RETENTION_FILE_SETTING
+        file_info_without_large_file_sha1 = self._get_file_info_without_large_file_sha1(file_info)
+
+        logger.debug('Checking for matching unfinished large files for %s...', file_name)
         for file_ in self.services.large_file.list_unfinished_large_files(
             bucket_id, prefix=file_name
         ):
             if file_.file_name != file_name:
+                logger.debug('Rejecting %s: file has a different file name', file_.file_id)
                 continue
             if file_.file_info != file_info:
-                continue
+                if (LARGE_FILE_SHA1 in file_.file_info) == (LARGE_FILE_SHA1 in file_info):
+                    logger.debug(
+                        'Rejecting %s: large_file_sha1 is present or missing in both file infos',
+                        file_.file_id
+                    )
+                    continue
+
+                if self._get_file_info_without_large_file_sha1(
+                    file_.file_info
+                ) != file_info_without_large_file_sha1:
+                    # ignoring the large_file_sha1 file infos are still different
+                    logger.debug(
+                        'Rejecting %s: file info mismatch after dropping `large_file_sha1`',
+                        file_.file_id
+                    )
+                    continue
+
             # FIXME: what if `encryption is None` - match ANY encryption? :)
             if encryption is not None and encryption != file_.encryption:
+                logger.debug('Rejecting %s: encryption mismatch', file_.file_id)
                 continue
 
             if legal_hold is None:
                 if LegalHold.UNSET != file_.legal_hold:
                     # Uploading and not providing legal_hold means that server's response about that file version
                     # will have legal_hold=LegalHold.UNSET
+                    logger.debug('Rejecting %s: legal hold mismatch (not unset)', file_.file_id)
                     continue
             elif legal_hold != file_.legal_hold:
+                logger.debug('Rejecting %s: legal hold mismatch', file_.file_id)
                 continue
 
             if file_retention != file_.file_retention:
                 # if `file_.file_retention` is UNKNOWN then we skip - lib user can still
                 # pass UNKNOWN file_retention here - but raw_api/server won't allow it
                 # and we don't check it here
+                logger.debug('Rejecting %s: retention mismatch', file_.file_id)
                 continue
             files_match = True
             finished_parts = {}
@@ -412,10 +444,17 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
 
             # Skip not matching files or unfinished files with no uploaded parts
             if not files_match or not finished_parts:
+                logger.debug('Rejecting %s: No finished parts or part mismatch', file_.file_id)
                 continue
 
             # Return first matched file
+            logger.debug(
+                'Unfinished file %s matches with %i finished parts', file_.file_id,
+                len(finished_parts)
+            )
             return file_, finished_parts
+
+        logger.debug('No matching unfinished files found.')
         return None, {}
 
 

--- a/b2sdk/transfer/emerge/executor.py
+++ b/b2sdk/transfer/emerge/executor.py
@@ -12,7 +12,7 @@ import logging
 import threading
 
 from abc import ABCMeta, abstractmethod
-from typing import Optional
+from typing import Dict, Optional
 
 from b2sdk.encryption.setting import EncryptionSetting
 from b2sdk.exception import MaxFileSizeExceeded
@@ -349,9 +349,16 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
                 best_match_parts_len = finished_parts_len
         return best_match_file, best_match_parts
 
-    @staticmethod
-    def _get_file_info_without_large_file_sha1(file_info):
-        return {k: v for k, v in file_info.items() if k != LARGE_FILE_SHA1}
+    @classmethod
+    def _get_file_info_without_large_file_sha1(
+        cls,
+        file_info: Optional[Dict[str, str]],
+    ) -> Optional[Dict[str, str]]:
+        if not file_info or LARGE_FILE_SHA1 not in file_info:
+            return file_info
+        out_file_info = dict(file_info)
+        del out_file_info[LARGE_FILE_SHA1]
+        return out_file_info
 
     def _match_unfinished_file_if_possible(
         self,

--- a/b2sdk/transfer/emerge/planner/planner.py
+++ b/b2sdk/transfer/emerge/planner/planner.py
@@ -14,7 +14,6 @@ import json
 
 from abc import ABCMeta, abstractmethod
 from collections import deque
-from itertools import chain
 
 from b2sdk.transfer.emerge.planner.part_definition import (
     CopyEmergePartDefinition,
@@ -25,6 +24,7 @@ from b2sdk.transfer.emerge.planner.upload_subpart import (
     LocalSourceUploadSubpart,
     RemoteSourceUploadSubpart,
 )
+from b2sdk.utils import iterator_peek
 
 MEGABYTE = 1000 * 1000
 GIGABYTE = 1000 * MEGABYTE
@@ -340,10 +340,10 @@ class EmergePlanner:
         return left_buff, UploadBuffer(left_buff.end_offset)
 
     def _select_intent_fragments(self, write_intent_iterator):
-        """ Select overapping write intent fragments to use.
+        """ Select overlapping write intent fragments to use.
 
         To solve overlapping intents selection, intents can be split to smaller fragments.
-        Those fragments are yieled as soon as decision can be made to use them,
+        Those fragments are yielded as soon as decision can be made to use them,
         so there is possibility that one intent is yielded in multiple fragments. Those
         would be merged again by higher level iterator that produces emerge parts, but
         in principle this merging can happen here. Not merging it is a code design decision
@@ -627,8 +627,10 @@ class EmergePlan(BaseEmergePlan):
 
 class StreamingEmergePlan(BaseEmergePlan):
     def __init__(self, emerge_parts_iterator):
-        emerge_parts, self._is_large_file = self._peek_for_large_file(emerge_parts_iterator)
-        super(StreamingEmergePlan, self).__init__(emerge_parts)
+        emerge_parts_iterator, self._is_large_file = self._peek_for_large_file(
+            emerge_parts_iterator
+        )
+        super().__init__(emerge_parts_iterator)
 
     def is_large_file(self):
         return self._is_large_file
@@ -640,15 +642,12 @@ class StreamingEmergePlan(BaseEmergePlan):
         return None
 
     def _peek_for_large_file(self, emerge_parts_iterator):
-        first_part = next(emerge_parts_iterator, None)
-        if first_part is None:
+        peeked, emerge_parts_iterator = iterator_peek(emerge_parts_iterator, 2)
+
+        if not peeked:
             raise ValueError('Empty emerge parts iterator')
 
-        second_part = next(emerge_parts_iterator, None)
-        if second_part is None:
-            return iter([first_part]), False
-        else:
-            return chain([first_part, second_part], emerge_parts_iterator), True
+        return emerge_parts_iterator, len(peeked) > 1
 
 
 class EmergePart:

--- a/b2sdk/transfer/emerge/write_intent.py
+++ b/b2sdk/transfer/emerge/write_intent.py
@@ -8,6 +8,10 @@
 #
 ######################################################################
 
+from typing import Optional
+
+from b2sdk.utils import Sha1HexDigest
+
 
 class WriteIntent:
     """ Wrapper for outbound source that defines destination offset. """
@@ -62,6 +66,19 @@ class WriteIntent:
         :rtype: bool
         """
         return self.outbound_source.is_upload()
+
+    def get_large_file_sha1(self) -> Optional[Sha1HexDigest]:
+        """
+        Return a 40-character string containing the hex SHA1 checksum, which can be used as the `large_file_sha1` entry.
+
+        This method is only used if a large file is constructed from only a single source.  If that source's hash is known,
+        the result file's SHA1 checksum will be the same and can be copied.
+
+        If the source's sha1 is unknown and can't be calculated, `None` is returned.
+
+        :rtype str:
+        """
+        return self.outbound_source.get_large_file_sha1()
 
     @classmethod
     def wrap_sources_iterator(cls, outbound_sources_iterator):

--- a/b2sdk/transfer/emerge/write_intent.py
+++ b/b2sdk/transfer/emerge/write_intent.py
@@ -67,7 +67,7 @@ class WriteIntent:
         """
         return self.outbound_source.is_upload()
 
-    def get_large_file_sha1(self) -> Optional[Sha1HexDigest]:
+    def get_content_sha1(self) -> Optional[Sha1HexDigest]:
         """
         Return a 40-character string containing the hex SHA1 checksum, which can be used as the `large_file_sha1` entry.
 
@@ -78,7 +78,7 @@ class WriteIntent:
 
         :rtype str:
         """
-        return self.outbound_source.get_large_file_sha1()
+        return self.outbound_source.get_content_sha1()
 
     @classmethod
     def wrap_sources_iterator(cls, outbound_sources_iterator):

--- a/b2sdk/transfer/outbound/copy_source.py
+++ b/b2sdk/transfer/outbound/copy_source.py
@@ -82,7 +82,7 @@ class CopySource(OutboundTransferSource):
             source_content_type=self.source_content_type
         )
 
-    def get_large_file_sha1(self):
+    def get_content_sha1(self):
         if self.offset or self.length:
             # this is a copy of only a range of the source, can't copy the SHA1
             return None

--- a/b2sdk/transfer/outbound/copy_source.py
+++ b/b2sdk/transfer/outbound/copy_source.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from b2sdk.encryption.setting import EncryptionSetting
 from b2sdk.transfer.outbound.outbound_source import OutboundTransferSource
+from b2sdk.http_constants import LARGE_FILE_SHA1
 
 
 class CopySource(OutboundTransferSource):
@@ -80,3 +81,9 @@ class CopySource(OutboundTransferSource):
             source_file_info=self.source_file_info,
             source_content_type=self.source_content_type
         )
+
+    def get_large_file_sha1(self):
+        if self.offset or self.length:
+            # this is a copy of only a range of the source, can't copy the SHA1
+            return None
+        return self.source_file_info.get(LARGE_FILE_SHA1)

--- a/b2sdk/transfer/outbound/outbound_source.py
+++ b/b2sdk/transfer/outbound/outbound_source.py
@@ -9,6 +9,9 @@
 ######################################################################
 
 from abc import ABCMeta, abstractmethod
+from typing import Optional
+
+from b2sdk.utils import Sha1HexDigest
 
 
 class OutboundTransferSource(metaclass=ABCMeta):
@@ -29,6 +32,19 @@ class OutboundTransferSource(metaclass=ABCMeta):
     def get_content_length(self):
         """
         Return the number of bytes of data in the file.
+        """
+
+    @abstractmethod
+    def get_large_file_sha1(self) -> Optional[Sha1HexDigest]:
+        """
+        Return a 40-character string containing the hex SHA1 checksum, which can be used as the `large_file_sha1` entry.
+
+        This method is only used if a large file is constructed from only a single source.  If that source's hash is known,
+        the result file's SHA1 checksum will be the same and can be copied.
+
+        If the source's sha1 is unknown and can't be calculated, `None` is returned. 
+ 
+        :rtype str:
         """
 
     @abstractmethod

--- a/b2sdk/transfer/outbound/outbound_source.py
+++ b/b2sdk/transfer/outbound/outbound_source.py
@@ -48,11 +48,11 @@ class OutboundTransferSource(metaclass=ABCMeta):
     @abstractmethod
     def is_upload(self) -> bool:
         """
-        Return if outbound source is an upload source.
+        Returns True if outbound source is an upload source.
         """
 
     @abstractmethod
     def is_copy(self) -> bool:
         """
-        Returns if outbound source is a copy source.
+        Returns True if outbound source is a copy source.
         """

--- a/b2sdk/transfer/outbound/outbound_source.py
+++ b/b2sdk/transfer/outbound/outbound_source.py
@@ -35,7 +35,7 @@ class OutboundTransferSource(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def get_large_file_sha1(self) -> Optional[Sha1HexDigest]:
+    def get_content_sha1(self) -> Optional[Sha1HexDigest]:
         """
         Return a 40-character string containing the hex SHA1 checksum, which can be used as the `large_file_sha1` entry.
 

--- a/b2sdk/transfer/outbound/upload_source.py
+++ b/b2sdk/transfer/outbound/upload_source.py
@@ -27,7 +27,7 @@ class AbstractUploadSource(OutboundTransferSource):
     """
 
     @abstractmethod
-    def get_content_sha1(self) -> str:
+    def get_content_sha1(self) -> Optional[Sha1HexDigest]:
         """
         Returns a 40-character string containing the hex SHA1 checksum of the data in the file.
         """
@@ -37,9 +37,6 @@ class AbstractUploadSource(OutboundTransferSource):
         """
         Returns a binary file-like object from which the data can be read.
         """
-
-    def get_large_file_sha1(self) -> Optional[Sha1HexDigest]:
-        return self.get_content_sha1()
 
     def is_upload(self) -> bool:
         return True
@@ -57,7 +54,11 @@ class AbstractUploadSource(OutboundTransferSource):
 
 
 class UploadSourceBytes(AbstractUploadSource):
-    def __init__(self, data_bytes: Union[bytes, bytearray], content_sha1: Optional[str] = None):
+    def __init__(
+        self,
+        data_bytes: Union[bytes, bytearray],
+        content_sha1: Optional[Sha1HexDigest] = None,
+    ):
         """
         Initialize upload source using given bytes.
 
@@ -91,7 +92,11 @@ class UploadSourceBytes(AbstractUploadSource):
 
 
 class UploadSourceLocalFile(AbstractUploadSource):
-    def __init__(self, local_path: Union[os.PathLike, str], content_sha1: Optional[str] = None):
+    def __init__(
+        self,
+        local_path: Union[os.PathLike, str],
+        content_sha1: Optional[Sha1HexDigest] = None,
+    ):
         """
         Initialize upload source using provided path.
 
@@ -144,7 +149,7 @@ class UploadSourceLocalFileRange(UploadSourceLocalFile):
     def __init__(
         self,
         local_path: Union[os.PathLike, str],
-        content_sha1: Optional[str] = None,
+        content_sha1: Optional[Sha1HexDigest] = None,
         offset: int = 0,
         length: Optional[int] = None,
     ):
@@ -190,7 +195,7 @@ class UploadSourceStream(AbstractUploadSource):
         self,
         stream_opener: Callable[[], io.IOBase],
         stream_length: Optional[int] = None,
-        stream_sha1: Optional[str] = None,
+        stream_sha1: Optional[Sha1HexDigest] = None,
     ):
         """
         Initialize upload source using arbitrary function.
@@ -245,7 +250,7 @@ class UploadSourceStreamRange(UploadSourceStream):
         stream_opener: Callable[[], io.IOBase],
         offset: int = 0,
         stream_length: Optional[int] = None,
-        stream_sha1: Optional[str] = None,
+        stream_sha1: Optional[Sha1HexDigest] = None,
     ):
         """
         Initialize upload source using arbitrary function.

--- a/b2sdk/transfer/outbound/upload_source.py
+++ b/b2sdk/transfer/outbound/upload_source.py
@@ -13,11 +13,12 @@ import io
 import os
 
 from abc import abstractmethod
+from typing import Optional
 
 from b2sdk.exception import InvalidUploadSource
 from b2sdk.stream.range import RangeOfInputStream, wrap_with_range
 from b2sdk.transfer.outbound.outbound_source import OutboundTransferSource
-from b2sdk.utils import hex_sha1_of_stream, hex_sha1_of_unlimited_stream
+from b2sdk.utils import hex_sha1_of_stream, hex_sha1_of_unlimited_stream, Sha1HexDigest
 
 
 class AbstractUploadSource(OutboundTransferSource):
@@ -38,6 +39,9 @@ class AbstractUploadSource(OutboundTransferSource):
         data can be read.
         :return:
         """
+
+    def get_large_file_sha1(self) -> Optional[Sha1HexDigest]:
+        return self.get_content_sha1()
 
     def is_upload(self):
         return True

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -321,7 +321,7 @@ To support automatic continuation, some advanced methods create a plan before st
 If that is not available, ``large_file_id`` can be extracted via callback during the operation start. It can then be passed into the subsequent call to continue the same task, though the responsibility for passing the exact same input is then on the user of the function. Please see :ref:`advanced method support table <advanced_methods_support_table>` to see where automatic continuation is supported. ``large_file_id`` can also be passed if automatic continuation is available in order to avoid issues where multiple matching upload sessions are matching the transfer.
 
 
-Continuation of create/concantenate
+Continuation of create/concatenate
 ===================================
 
 :meth:`b2sdk.v2.Bucket.create_file` supports automatic continuation or manual continuation. :meth:`b2sdk.v2.Bucket.create_file_stream` supports only manual continuation for local-only inputs. The situation looks the same for :meth:`b2sdk.v2.Bucket.concatenate` and :meth:`b2sdk.v2.Bucket.concatenate_stream` (streamed version supports only manual continuation of local sources). Also :meth:`b2sdk.v2.Bucket.upload` and :meth:`b2sdk.v2.Bucket.copy` support both automatic and manual continuation.
@@ -376,3 +376,14 @@ No continuation
 
 
 Note, that this only forces start of a new large file - it is still possible to continue the process with either auto or manual modes.
+
+
+****************************
+SHA-1 hashes for large files
+****************************
+
+Depending on the number and size of sources and the size of the result file, the SDK may decide to use the large file API to create a file on the server.  In such cases the file's SHA-1 won't be stored on the server in the ``X-Bz-Content-Sha1`` header, but it may optionally be stored with the file in the ``large_file_sha1`` entry in the ``file_info``, as per [B2 integration checklist](https://www.backblaze.com/b2/docs/integration_checklist.html).
+
+In basic scenarios, large files uploaded to the server will have a ``large_file_sha1`` element added automatically to their ``file_info``.  However, when concatenating multiple sources, it may be impossible for the SDK to figure out the SHA-1 automatically.  In such cases, the SHA-1 can be provided using the ``large_file_sha1`` parameter to :meth:`b2sdk.v2.Bucket.create_file`, :meth:`b2sdk.v2.Bucket.concatenate` and their stream equivalents.  If the parameter is skipped or ``None``, the result file may not have the ``large_file_sha1`` value set.
+
+Note that the provided SHA-1 value is not verified.

--- a/test/integration/test_download.py
+++ b/test/integration/test_download.py
@@ -12,10 +12,11 @@ import gzip
 import io
 import pathlib
 from pprint import pprint
-from typing import Optional
+from typing import Optional, Tuple
 from unittest import mock
 
 from b2sdk.v2 import *
+from b2sdk.utils import Sha1HexDigest
 
 from .fixtures import *  # pyflakes: disable
 from .helpers import authorize
@@ -49,14 +50,17 @@ class TestDownload(IntegrationTestBase):
                         bucket.download_file_by_name('a_single_zero').save(io_)
                 assert exc_info.value.args == ('no strategy suitable for download was found!',)
 
-                f = self._file_helper(bucket)
+                f, sha1 = self._file_helper(bucket)
                 if zero._type() != 'large':
                     # if we are here, that's not the production server!
                     assert f.download_version.content_sha1_verified  # large files don't have sha1, lets not check
 
-    def _file_helper(
-        self, bucket, sha1_sum=None, bytes_to_write: Optional[int] = None
-    ) -> DownloadVersion:
+                file_info = f.download_version.file_info
+                assert LARGE_FILE_SHA1 in file_info
+                assert file_info[LARGE_FILE_SHA1] == sha1
+
+    def _file_helper(self, bucket, sha1_sum=None,
+                     bytes_to_write: Optional[int] = None) -> Tuple[DownloadVersion, Sha1HexDigest]:
         bytes_to_write = bytes_to_write or int(self.info.get_absolute_minimum_part_size()) * 2 + 1
         with TempDir() as temp_dir:
             temp_dir = pathlib.Path(temp_dir)
@@ -72,17 +76,19 @@ class TestDownload(IntegrationTestBase):
 
             f = bucket.download_file_by_name('small_file')
             f.save_to(target_small_file)
-            assert hex_sha1_of_file(source_small_file) == hex_sha1_of_file(target_small_file)
-        return f
+
+            source_sha1 = hex_sha1_of_file(source_small_file)
+            assert source_sha1 == hex_sha1_of_file(target_small_file)
+        return f, source_sha1[0]
 
     def test_small(self):
         bucket = self.create_bucket()
-        f = self._file_helper(bucket, bytes_to_write=1)
+        f, _ = self._file_helper(bucket, bytes_to_write=1)
         assert f.download_version.content_sha1_verified
 
     def test_small_unverified(self):
         bucket = self.create_bucket()
-        f = self._file_helper(bucket, sha1_sum='do_not_verify', bytes_to_write=1)
+        f, _ = self._file_helper(bucket, sha1_sum='do_not_verify', bytes_to_write=1)
         if f.download_version.content_sha1_verified:
             pprint(f.download_version._get_args_for_clone())
             assert not f.download_version.content_sha1_verified

--- a/test/unit/bucket/test_bucket.py
+++ b/test/unit/bucket/test_bucket.py
@@ -1467,7 +1467,7 @@ class TestUpload(TestCaseWithBucket):
     def test_upload_large(self):
         data = self._make_data(self.simulator.MIN_PART_SIZE * 3)
         progress_listener = StubProgressListener()
-        print(self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener))
+        self.bucket.upload_bytes(data, 'file1', progress_listener=progress_listener)
         self._check_file_contents('file1', data)
         self._check_large_file_sha1('file1', hex_sha1_of_bytes(data))
         self.assertTrue(progress_listener.is_valid())


### PR DESCRIPTION
With this change `large_file_sha1` entries are now added to `file_info` automatically if possible.  In advanced used cases the `large_file_sha1` can be provided manually to some of `Bucket`'s methods.