### PR TITLE
Format with an adjusted PyCharm formatter

### DIFF
--- a/b2sdk/__init__.py
+++ b/b2sdk/__init__.py
@@ -22,6 +22,7 @@ class UrllibWarningFilter:
 logging.getLogger('urllib3.connectionpool').addFilter(UrllibWarningFilter())
 
 import b2sdk.version
+
 __version__ = b2sdk.version.VERSION
 assert __version__  # PEP-0396
 
@@ -32,4 +33,5 @@ except ImportError:
     pass
 else:
     import warnings
+
     warnings.simplefilter("ignore", ArrowParseWarning)

--- a/b2sdk/_v3/__init__.py
+++ b/b2sdk/_v3/__init__.py
@@ -17,14 +17,21 @@ from b2sdk.api import B2Api
 from b2sdk.api import Services
 from b2sdk.bucket import Bucket
 from b2sdk.bucket import BucketFactory
-from b2sdk.raw_api import ALL_CAPABILITIES, REALM_URLS
+from b2sdk.raw_api import (
+    ALL_CAPABILITIES,
+    REALM_URLS,
+)
 
 # encryption
 
 from b2sdk.encryption.setting import EncryptionSetting
 from b2sdk.encryption.setting import EncryptionSettingFactory
 from b2sdk.encryption.setting import EncryptionKey
-from b2sdk.encryption.setting import SSE_NONE, SSE_B2_AES, UNKNOWN_KEY_ID
+from b2sdk.encryption.setting import (
+    SSE_NONE,
+    SSE_B2_AES,
+    UNKNOWN_KEY_ID,
+)
 from b2sdk.encryption.types import EncryptionAlgorithm
 from b2sdk.encryption.types import EncryptionMode
 from b2sdk.http_constants import SSE_C_KEY_ID_FILE_INFO_KEY_NAME
@@ -44,8 +51,14 @@ from b2sdk.account_info.upload_url_pool import UrlPoolAccountInfo
 
 # version & version utils
 
-from b2sdk.version import VERSION, USER_AGENT
-from b2sdk.version_utils import rename_argument, rename_function
+from b2sdk.version import (
+    VERSION,
+    USER_AGENT,
+)
+from b2sdk.version_utils import (
+    rename_argument,
+    rename_function,
+)
 
 # utils
 
@@ -197,7 +210,11 @@ from b2sdk.scan.folder import AbstractFolder
 from b2sdk.scan.folder import B2Folder
 from b2sdk.scan.folder import LocalFolder
 from b2sdk.scan.folder_parser import parse_folder
-from b2sdk.scan.path import AbstractPath, B2Path, LocalPath
+from b2sdk.scan.path import (
+    AbstractPath,
+    B2Path,
+    LocalPath,
+)
 from b2sdk.scan.policies import convert_dir_regex_to_dir_prefix_regex
 from b2sdk.scan.policies import DEFAULT_SCAN_MANAGER
 from b2sdk.scan.policies import IntegerRange

--- a/b2sdk/account_info/abstract.py
+++ b/b2sdk/account_info/abstract.py
@@ -12,7 +12,10 @@ from typing import Optional
 
 from b2sdk.account_info import exception
 from b2sdk.raw_api import ALL_CAPABILITIES
-from b2sdk.utils import B2TraceMetaAbstract, limit_trace_arguments
+from b2sdk.utils import (
+    B2TraceMetaAbstract,
+    limit_trace_arguments,
+)
 
 
 class AbstractAccountInfo(metaclass=B2TraceMetaAbstract):
@@ -133,7 +136,7 @@ class AbstractAccountInfo(metaclass=B2TraceMetaAbstract):
         if account_id == application_key_id:
             return True  # old style
         if len(application_key_id
-              ) == (3 + len(account_id) + len(new_style_master_key_suffix)):  # 3 for cluster id
+               ) == (3 + len(account_id) + len(new_style_master_key_suffix)):  # 3 for cluster id
             # new style
             if application_key_id.endswith(account_id + new_style_master_key_suffix):
                 return True
@@ -243,18 +246,18 @@ class AbstractAccountInfo(metaclass=B2TraceMetaAbstract):
         ]
     )
     def set_auth_data(
-        self,
-        account_id,
-        auth_token,
-        api_url,
-        download_url,
-        recommended_part_size,
-        absolute_minimum_part_size,
-        application_key,
-        realm,
-        s3_api_url,
-        allowed,
-        application_key_id,
+            self,
+            account_id,
+            auth_token,
+            api_url,
+            download_url,
+            recommended_part_size,
+            absolute_minimum_part_size,
+            application_key,
+            realm,
+            s3_api_url,
+            allowed,
+            application_key_id,
     ):
         """
         Check permission correctness and stores the results of ``b2_authorize_account``.
@@ -328,15 +331,15 @@ class AbstractAccountInfo(metaclass=B2TraceMetaAbstract):
         :rtype: bool
         """
         return (
-            ('bucketId' in allowed) and ('bucketName' in allowed) and
-            ((allowed['bucketId'] is not None) or (allowed['bucketName'] is None)) and
-            ('capabilities' in allowed) and ('namePrefix' in allowed)
+                ('bucketId' in allowed) and ('bucketName' in allowed) and
+                ((allowed['bucketId'] is not None) or (allowed['bucketName'] is None)) and
+                ('capabilities' in allowed) and ('namePrefix' in allowed)
         )
 
     @abstractmethod
     def _set_auth_data(
-        self, account_id, auth_token, api_url, download_url, recommended_part_size,
-        absolute_minimum_part_size, application_key, realm, s3_api_url, allowed, application_key_id
+            self, account_id, auth_token, api_url, download_url, recommended_part_size,
+            absolute_minimum_part_size, application_key, realm, s3_api_url, allowed, application_key_id
     ):
         """
         Actually store the auth data.  Can assume that 'allowed' is present and valid.

--- a/b2sdk/account_info/in_memory.py
+++ b/b2sdk/account_info/in_memory.py
@@ -61,8 +61,8 @@ class InMemoryAccountInfo(UrlPoolAccountInfo):
         self._s3_api_url = None
 
     def _set_auth_data(
-        self, account_id, auth_token, api_url, download_url, recommended_part_size,
-        absolute_minimum_part_size, application_key, realm, s3_api_url, allowed, application_key_id
+            self, account_id, auth_token, api_url, download_url, recommended_part_size,
+            absolute_minimum_part_size, application_key, realm, s3_api_url, allowed, application_key_id
     ):
         self._account_id = account_id
         self._application_key_id = application_key_id

--- a/b2sdk/account_info/sqlite_account_info.py
+++ b/b2sdk/account_info/sqlite_account_info.py
@@ -16,9 +16,15 @@ import sqlite3
 import stat
 import threading
 
-from typing import List, Optional
+from typing import (
+    List,
+    Optional,
+)
 
-from .exception import CorruptAccountInfo, MissingAccountData
+from .exception import (
+    CorruptAccountInfo,
+    MissingAccountData,
+)
 from .upload_url_pool import UrlPoolAccountInfo
 
 logger = logging.getLogger(__name__)
@@ -30,6 +36,8 @@ B2_ACCOUNT_INFO_PROFILE_NAME_REGEXP = re.compile(r'[a-zA-Z0-9_\-]{1,64}')
 XDG_CONFIG_HOME_ENV_VAR = 'XDG_CONFIG_HOME'
 
 DEFAULT_ABSOLUTE_MINIMUM_PART_SIZE = 5000000  # this value is used ONLY in migrating db, and in v1 wrapper, it is not
+
+
 # meant to be a default for other applications
 
 
@@ -391,18 +399,18 @@ class SqliteAccountInfo(UrlPoolAccountInfo):
             conn.execute('DELETE FROM bucket_upload_url;')
 
     def _set_auth_data(
-        self,
-        account_id,
-        auth_token,
-        api_url,
-        download_url,
-        recommended_part_size,
-        absolute_minimum_part_size,
-        application_key,
-        realm,
-        s3_api_url,
-        allowed,
-        application_key_id,
+            self,
+            account_id,
+            auth_token,
+            api_url,
+            download_url,
+            recommended_part_size,
+            absolute_minimum_part_size,
+            application_key,
+            realm,
+            s3_api_url,
+            allowed,
+            application_key_id,
     ):
         assert self.allowed_is_valid(allowed)
         with self._get_connection() as conn:
@@ -433,14 +441,14 @@ class SqliteAccountInfo(UrlPoolAccountInfo):
             )
 
     def set_auth_data_with_schema_0_for_test(
-        self,
-        account_id,
-        auth_token,
-        api_url,
-        download_url,
-        minimum_part_size,
-        application_key,
-        realm,
+            self,
+            account_id,
+            auth_token,
+            api_url,
+            download_url,
+            minimum_part_size,
+            application_key,
+            realm,
     ):
         """
         Set authentication data for tests.

--- a/b2sdk/account_info/stub.py
+++ b/b2sdk/account_info/stub.py
@@ -42,18 +42,18 @@ class StubAccountInfo(AbstractAccountInfo):
             del self.buckets[bucket_id]
 
     def _set_auth_data(
-        self,
-        account_id,
-        auth_token,
-        api_url,
-        download_url,
-        recommended_part_size,
-        absolute_minimum_part_size,
-        application_key,
-        realm,
-        s3_api_url,
-        allowed,
-        application_key_id,
+            self,
+            account_id,
+            auth_token,
+            api_url,
+            download_url,
+            recommended_part_size,
+            absolute_minimum_part_size,
+            application_key,
+            realm,
+            s3_api_url,
+            allowed,
+            application_key_id,
     ):
         self.account_id = account_id
         self.auth_token = auth_token

--- a/b2sdk/api.py
+++ b/b2sdk/api.py
@@ -8,19 +8,46 @@
 #
 ######################################################################
 
-from typing import Optional, Tuple, List, Generator
+from typing import (
+    Optional,
+    Tuple,
+    List,
+    Generator,
+)
 from contextlib import suppress
 
 from .account_info.abstract import AbstractAccountInfo
-from .api_config import B2HttpApiConfig, DEFAULT_HTTP_API_CONFIG
-from .application_key import ApplicationKey, BaseApplicationKey, FullApplicationKey
+from .api_config import (
+    B2HttpApiConfig,
+    DEFAULT_HTTP_API_CONFIG,
+)
+from .application_key import (
+    ApplicationKey,
+    BaseApplicationKey,
+    FullApplicationKey,
+)
 from .cache import AbstractCache
-from .bucket import Bucket, BucketFactory
+from .bucket import (
+    Bucket,
+    BucketFactory,
+)
 from .encryption.setting import EncryptionSetting
 from .replication.setting import ReplicationConfiguration
-from .exception import BucketIdNotFound, NonExistentBucket, RestrictedBucket
-from .file_lock import FileRetentionSetting, LegalHold
-from .file_version import DownloadVersionFactory, FileIdAndName, FileVersion, FileVersionFactory
+from .exception import (
+    BucketIdNotFound,
+    NonExistentBucket,
+    RestrictedBucket,
+)
+from .file_lock import (
+    FileRetentionSetting,
+    LegalHold,
+)
+from .file_version import (
+    DownloadVersionFactory,
+    FileIdAndName,
+    FileVersion,
+    FileVersionFactory,
+)
 from .large_file.services import LargeFileServices
 from .raw_api import API_VERSION
 from .progress import AbstractProgressListener
@@ -32,7 +59,11 @@ from .transfer import (
     UploadManager,
 )
 from .transfer.inbound.downloaded_file import DownloadedFile
-from .utils import B2TraceMeta, b2_url_encode, limit_trace_arguments
+from .utils import (
+    B2TraceMeta,
+    b2_url_encode,
+    limit_trace_arguments,
+)
 
 
 def url_for_api(info, api_name):
@@ -57,14 +88,14 @@ class Services:
     DOWNLOAD_MANAGER_CLASS = staticmethod(DownloadManager)
 
     def __init__(
-        self,
-        api,
-        max_upload_workers: Optional[int] = None,
-        max_copy_workers: Optional[int] = None,
-        max_download_workers: Optional[int] = None,
-        save_to_buffer_size: Optional[int] = None,
-        check_download_hash: bool = True,
-        max_download_streams_per_file: Optional[int] = None,
+            self,
+            api,
+            max_upload_workers: Optional[int] = None,
+            max_copy_workers: Optional[int] = None,
+            max_download_workers: Optional[int] = None,
+            save_to_buffer_size: Optional[int] = None,
+            check_download_hash: bool = True,
+            max_download_streams_per_file: Optional[int] = None,
     ):
         """
         Initialize Services object using given session.
@@ -124,16 +155,16 @@ class B2Api(metaclass=B2TraceMeta):
     DEFAULT_LIST_KEY_COUNT = 1000
 
     def __init__(
-        self,
-        account_info: Optional[AbstractAccountInfo] = None,
-        cache: Optional[AbstractCache] = None,
-        max_upload_workers: Optional[int] = None,
-        max_copy_workers: Optional[int] = None,
-        api_config: B2HttpApiConfig = DEFAULT_HTTP_API_CONFIG,
-        max_download_workers: Optional[int] = None,
-        save_to_buffer_size: Optional[int] = None,
-        check_download_hash: bool = True,
-        max_download_streams_per_file: Optional[int] = None,
+            self,
+            account_info: Optional[AbstractAccountInfo] = None,
+            cache: Optional[AbstractCache] = None,
+            max_upload_workers: Optional[int] = None,
+            max_copy_workers: Optional[int] = None,
+            api_config: B2HttpApiConfig = DEFAULT_HTTP_API_CONFIG,
+            max_download_workers: Optional[int] = None,
+            save_to_buffer_size: Optional[int] = None,
+            check_download_hash: bool = True,
+            max_download_streams_per_file: Optional[int] = None,
     ):
         """
         Initialize the API using the given account info.
@@ -213,15 +244,15 @@ class B2Api(metaclass=B2TraceMeta):
     # buckets
 
     def create_bucket(
-        self,
-        name,
-        bucket_type,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        is_file_lock_enabled: Optional[bool] = None,
-        replication: Optional[ReplicationConfiguration] = None,
+            self,
+            name,
+            bucket_type,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            is_file_lock_enabled: Optional[bool] = None,
+            replication: Optional[ReplicationConfiguration] = None,
     ):
         """
         Create a bucket.
@@ -261,11 +292,11 @@ class B2Api(metaclass=B2TraceMeta):
         return bucket
 
     def download_file_by_id(
-        self,
-        file_id: str,
-        progress_listener: Optional[AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            file_id: str,
+            progress_listener: Optional[AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[EncryptionSetting] = None,
     ) -> DownloadedFile:
         """
         Download a file with the given ID.
@@ -285,11 +316,11 @@ class B2Api(metaclass=B2TraceMeta):
         )
 
     def update_file_retention(
-        self,
-        file_id: str,
-        file_name: str,
-        file_retention: FileRetentionSetting,
-        bypass_governance: bool = False,
+            self,
+            file_id: str,
+            file_name: str,
+            file_retention: FileRetentionSetting,
+            bypass_governance: bool = False,
     ) -> FileRetentionSetting:
         return FileRetentionSetting.from_server_response(
             self.session.update_file_retention(
@@ -301,10 +332,10 @@ class B2Api(metaclass=B2TraceMeta):
         )
 
     def update_file_legal_hold(
-        self,
-        file_id: str,
-        file_name: str,
-        legal_hold: LegalHold,
+            self,
+            file_id: str,
+            file_name: str,
+            legal_hold: LegalHold,
     ) -> LegalHold:
         return LegalHold.from_server_response(
             self.session.update_file_legal_hold(
@@ -465,12 +496,12 @@ class B2Api(metaclass=B2TraceMeta):
 
     # keys
     def create_key(
-        self,
-        capabilities: List[str],
-        key_name: str,
-        valid_duration_seconds: Optional[int] = None,
-        bucket_id: Optional[str] = None,
-        name_prefix: Optional[str] = None,
+            self,
+            capabilities: List[str],
+            key_name: str,
+            valid_duration_seconds: Optional[int] = None,
+            bucket_id: Optional[str] = None,
+            name_prefix: Optional[str] = None,
     ):
         """
         Create a new :term:`application key`.
@@ -517,7 +548,7 @@ class B2Api(metaclass=B2TraceMeta):
         return ApplicationKey.from_api_response(response)
 
     def list_keys(self, start_application_key_id: Optional[str] = None
-                 ) -> Generator[ApplicationKey, None, None]:
+                  ) -> Generator[ApplicationKey, None, None]:
         """
         List application keys. Lazily perform requests to B2 cloud and return all keys.
 

--- a/b2sdk/api_config.py
+++ b/b2sdk/api_config.py
@@ -8,10 +8,17 @@
 #
 ######################################################################
 
-from typing import Optional, Callable, Type
+from typing import (
+    Optional,
+    Callable,
+    Type,
+)
 import requests
 
-from .raw_api import AbstractRawApi, B2RawHTTPApi
+from .raw_api import (
+    AbstractRawApi,
+    B2RawHTTPApi,
+)
 
 
 class B2HttpApiConfig:
@@ -19,12 +26,12 @@ class B2HttpApiConfig:
     DEFAULT_RAW_API_CLASS = B2RawHTTPApi
 
     def __init__(
-        self,
-        http_session_factory: Callable[[], requests.Session] = requests.Session,
-        install_clock_skew_hook: bool = True,
-        user_agent_append: Optional[str] = None,
-        _raw_api_class: Optional[Type[AbstractRawApi]] = None,
-        decode_content: bool = False
+            self,
+            http_session_factory: Callable[[], requests.Session] = requests.Session,
+            install_clock_skew_hook: bool = True,
+            user_agent_append: Optional[str] = None,
+            _raw_api_class: Optional[Type[AbstractRawApi]] = None,
+            decode_content: bool = False
     ):
         """
         A structure with params to be passed to low level API.

--- a/b2sdk/application_key.py
+++ b/b2sdk/application_key.py
@@ -8,22 +8,25 @@
 #
 ######################################################################
 
-from typing import List, Optional
+from typing import (
+    List,
+    Optional,
+)
 
 
 class BaseApplicationKey:
     """Common methods for ApplicationKey and FullApplicationKey."""
 
     def __init__(
-        self,
-        key_name: str,
-        application_key_id: str,
-        capabilities: List[str],
-        account_id: str,
-        expiration_timestamp_millis: Optional[int] = None,
-        bucket_id: Optional[str] = None,
-        name_prefix: Optional[str] = None,
-        options: Optional[List[str]] = None,
+            self,
+            key_name: str,
+            application_key_id: str,
+            capabilities: List[str],
+            account_id: str,
+            expiration_timestamp_millis: Optional[int] = None,
+            bucket_id: Optional[str] = None,
+            name_prefix: Optional[str] = None,
+            options: Optional[List[str]] = None,
     ):
         """
         :param key_name: name of the key, assigned by user
@@ -103,16 +106,16 @@ class FullApplicationKey(BaseApplicationKey):
     """Dataclass for storing info about an application key, including the actual key, as returned by create-key."""
 
     def __init__(
-        self,
-        key_name: str,
-        application_key_id: str,
-        application_key: str,
-        capabilities: List[str],
-        account_id: str,
-        expiration_timestamp_millis: Optional[int] = None,
-        bucket_id: Optional[str] = None,
-        name_prefix: Optional[str] = None,
-        options: Optional[List[str]] = None,
+            self,
+            key_name: str,
+            application_key_id: str,
+            application_key: str,
+            capabilities: List[str],
+            account_id: str,
+            expiration_timestamp_millis: Optional[int] = None,
+            bucket_id: Optional[str] = None,
+            name_prefix: Optional[str] = None,
+            options: Optional[List[str]] = None,
     ):
         """
         :param key_name: name of the key, assigned by user

--- a/b2sdk/b2http.py
+++ b/b2sdk/b2http.py
@@ -19,13 +19,29 @@ import requests
 from requests.adapters import HTTPAdapter
 import time
 
-from typing import Any, Dict, Optional
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
 
 from .exception import (
-    B2Error, B2RequestTimeoutDuringUpload, BadDateFormat, BrokenPipe, B2ConnectionError,
-    B2RequestTimeout, ClockSkew, ConnectionReset, interpret_b2_error, UnknownError, UnknownHost
+    B2Error,
+    B2RequestTimeoutDuringUpload,
+    BadDateFormat,
+    BrokenPipe,
+    B2ConnectionError,
+    B2RequestTimeout,
+    ClockSkew,
+    ConnectionReset,
+    interpret_b2_error,
+    UnknownError,
+    UnknownHost,
 )
-from .api_config import B2HttpApiConfig, DEFAULT_HTTP_API_CONFIG
+from .api_config import (
+    B2HttpApiConfig,
+    DEFAULT_HTTP_API_CONFIG,
+)
 from .requests import NotDecompressingResponse
 from .version import USER_AGENT
 
@@ -190,13 +206,13 @@ class B2Http:
         self.callbacks.append(callback)
 
     def post_content_return_json(
-        self,
-        url,
-        headers,
-        data,
-        try_count: int = TRY_COUNT_DATA,
-        post_params=None,
-        _timeout: Optional[int] = None,
+            self,
+            url,
+            headers,
+            data,
+            try_count: int = TRY_COUNT_DATA,
+            post_params=None,
+            _timeout: Optional[int] = None,
     ):
         """
         Use like this:
@@ -215,7 +231,10 @@ class B2Http:
         :return: a dict that is the decoded JSON
         :rtype: dict
         """
-        request_headers = {**headers, 'User-Agent': self.user_agent}
+        request_headers = {
+            **headers,
+            'User-Agent': self.user_agent
+        }
 
         # Do the HTTP POST.  This may retry, so each post needs to
         # rewind the data back to the beginning.
@@ -306,7 +325,10 @@ class B2Http:
         :param int try_count: a number or retries
         :return: Context manager that returns an object that supports iter_content()
         """
-        request_headers = {**headers, 'User-Agent': self.user_agent}
+        request_headers = {
+            **headers,
+            'User-Agent': self.user_agent
+        }
 
         # Do the HTTP GET.
         def do_get():
@@ -321,10 +343,10 @@ class B2Http:
         return ResponseContextManager(response)
 
     def head_content(
-        self,
-        url: str,
-        headers: Dict[str, Any],
-        try_count: int = TRY_COUNT_HEAD,
+            self,
+            url: str,
+            headers: Dict[str, Any],
+            try_count: int = TRY_COUNT_HEAD,
     ) -> Dict[str, Any]:
         """
         Does a HEAD instead of a GET for the URL.
@@ -349,7 +371,10 @@ class B2Http:
         :return: the decoded response
         :rtype: dict
         """
-        request_headers = {**headers, 'User-Agent': self.user_agent}
+        request_headers = {
+            **headers,
+            'User-Agent': self.user_agent
+        }
 
         # Do the HTTP HEAD.
         def do_head():
@@ -524,7 +549,7 @@ def test_http():
     # Successful get
     print('TEST: get')
     with b2_http.get_content(
-        'https://api.backblazeb2.com/test/echo_zeros?length=10', {}
+            'https://api.backblazeb2.com/test/echo_zeros?length=10', {}
     ) as response:
         assert response.status_code == 200
         response_data = b''.join(response.iter_content())

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -10,9 +10,15 @@
 
 import logging
 
-from typing import Optional, Tuple
+from typing import (
+    Optional,
+    Tuple,
+)
 
-from .encryption.setting import EncryptionSetting, EncryptionSettingFactory
+from .encryption.setting import (
+    EncryptionSetting,
+    EncryptionSettingFactory,
+)
 from .encryption.types import EncryptionMode
 from .exception import (
     BucketIdNotFound,
@@ -29,14 +35,26 @@ from .file_lock import (
     FileRetentionSetting,
     LegalHold,
 )
-from .file_version import DownloadVersion, FileVersion
-from .progress import AbstractProgressListener, DoNothingProgressListener
-from .replication.setting import ReplicationConfiguration, ReplicationConfigurationFactory
+from .file_version import (
+    DownloadVersion,
+    FileVersion,
+)
+from .progress import (
+    AbstractProgressListener,
+    DoNothingProgressListener,
+)
+from .replication.setting import (
+    ReplicationConfiguration,
+    ReplicationConfigurationFactory,
+)
 from .transfer.emerge.executor import AUTO_CONTENT_TYPE
 from .transfer.emerge.write_intent import WriteIntent
 from .transfer.inbound.downloaded_file import DownloadedFile
 from .transfer.outbound.copy_source import CopySource
-from .transfer.outbound.upload_source import UploadSourceBytes, UploadSourceLocalFile
+from .transfer.outbound.upload_source import (
+    UploadSourceBytes,
+    UploadSourceLocalFile,
+)
 from .utils import (
     B2TraceMeta,
     b2_url_encode,
@@ -56,23 +74,23 @@ class Bucket(metaclass=B2TraceMeta):
     DEFAULT_CONTENT_TYPE = AUTO_CONTENT_TYPE
 
     def __init__(
-        self,
-        api,
-        id_,
-        name=None,
-        type_=None,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        revision=None,
-        bucket_dict=None,
-        options_set=None,
-        default_server_side_encryption: EncryptionSetting = EncryptionSetting(
-            EncryptionMode.UNKNOWN
-        ),
-        default_retention: BucketRetentionSetting = UNKNOWN_BUCKET_RETENTION,
-        is_file_lock_enabled: Optional[bool] = None,
-        replication: Optional[ReplicationConfiguration] = None,
+            self,
+            api,
+            id_,
+            name=None,
+            type_=None,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            revision=None,
+            bucket_dict=None,
+            options_set=None,
+            default_server_side_encryption: EncryptionSetting = EncryptionSetting(
+                EncryptionMode.UNKNOWN
+            ),
+            default_retention: BucketRetentionSetting = UNKNOWN_BUCKET_RETENTION,
+            is_file_lock_enabled: Optional[bool] = None,
+            replication: Optional[ReplicationConfiguration] = None,
     ):
         """
         :param b2sdk.v2.B2Api api: an API object
@@ -141,16 +159,16 @@ class Bucket(metaclass=B2TraceMeta):
         return self.update(bucket_type=bucket_type)
 
     def update(
-        self,
-        bucket_type: Optional[str] = None,
-        bucket_info: Optional[dict] = None,
-        cors_rules: Optional[dict] = None,
-        lifecycle_rules: Optional[list] = None,
-        if_revision_is: Optional[int] = None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        default_retention: Optional[BucketRetentionSetting] = None,
-        replication: Optional[ReplicationConfiguration] = None,
-        is_file_lock_enabled: Optional[bool] = None,
+            self,
+            bucket_type: Optional[str] = None,
+            bucket_info: Optional[dict] = None,
+            cors_rules: Optional[dict] = None,
+            lifecycle_rules: Optional[list] = None,
+            if_revision_is: Optional[int] = None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            default_retention: Optional[BucketRetentionSetting] = None,
+            replication: Optional[ReplicationConfiguration] = None,
+            is_file_lock_enabled: Optional[bool] = None,
     ) -> 'Bucket':
         """
         Update various bucket parameters.
@@ -192,11 +210,11 @@ class Bucket(metaclass=B2TraceMeta):
         return self.api.cancel_large_file(file_id)
 
     def download_file_by_id(
-        self,
-        file_id: str,
-        progress_listener: Optional[AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            file_id: str,
+            progress_listener: Optional[AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[EncryptionSetting] = None,
     ) -> DownloadedFile:
         """
         Download a file by ID.
@@ -217,11 +235,11 @@ class Bucket(metaclass=B2TraceMeta):
         )
 
     def download_file_by_name(
-        self,
-        file_name: str,
-        progress_listener: Optional[AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            file_name: str,
+            progress_listener: Optional[AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[EncryptionSetting] = None,
     ) -> DownloadedFile:
         """
         Download a file by name.
@@ -319,11 +337,11 @@ class Bucket(metaclass=B2TraceMeta):
                 return
 
     def ls(
-        self,
-        folder_to_list: str = '',
-        latest_only: bool = True,
-        recursive: bool = False,
-        fetch_count: Optional[int] = 10000
+            self,
+            folder_to_list: str = '',
+            latest_only: bool = True,
+            recursive: bool = False,
+            fetch_count: Optional[int] = 10000
     ):
         """
         Pretend that folders exist and yields the information about the files in a folder.
@@ -434,15 +452,15 @@ class Bucket(metaclass=B2TraceMeta):
 
     @limit_trace_arguments(skip=('data_bytes',))
     def upload_bytes(
-        self,
-        data_bytes,
-        file_name,
-        content_type=None,
-        file_infos=None,
-        progress_listener=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            data_bytes,
+            file_name,
+            content_type=None,
+            file_infos=None,
+            progress_listener=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         """
         Upload bytes in memory to a B2 file.
@@ -470,17 +488,17 @@ class Bucket(metaclass=B2TraceMeta):
         )
 
     def upload_local_file(
-        self,
-        local_file,
-        file_name,
-        content_type=None,
-        file_infos=None,
-        sha1_sum=None,
-        min_part_size=None,
-        progress_listener=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            local_file,
+            file_name,
+            content_type=None,
+            file_infos=None,
+            sha1_sum=None,
+            min_part_size=None,
+            progress_listener=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         """
         Upload a file on local disk to a B2 file.
@@ -515,16 +533,16 @@ class Bucket(metaclass=B2TraceMeta):
         )
 
     def upload(
-        self,
-        upload_source,
-        file_name,
-        content_type=None,
-        file_info=None,
-        min_part_size=None,
-        progress_listener=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            upload_source,
+            file_name,
+            content_type=None,
+            file_info=None,
+            min_part_size=None,
+            progress_listener=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         """
         Upload a file to B2, retrying as needed.
@@ -562,19 +580,19 @@ class Bucket(metaclass=B2TraceMeta):
         )
 
     def create_file(
-        self,
-        write_intents,
-        file_name,
-        content_type=None,
-        file_info=None,
-        progress_listener=None,
-        recommended_upload_part_size=None,
-        continue_large_file_id=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        min_part_size=None,
-        max_part_size=None,
+            self,
+            write_intents,
+            file_name,
+            content_type=None,
+            file_info=None,
+            progress_listener=None,
+            recommended_upload_part_size=None,
+            continue_large_file_id=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            min_part_size=None,
+            max_part_size=None,
     ):
         """
         Creates a new file in this bucket using an iterable (list, tuple etc) of remote or local sources.
@@ -619,19 +637,19 @@ class Bucket(metaclass=B2TraceMeta):
         )
 
     def create_file_stream(
-        self,
-        write_intents_iterator,
-        file_name,
-        content_type=None,
-        file_info=None,
-        progress_listener=None,
-        recommended_upload_part_size=None,
-        continue_large_file_id=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        min_part_size=None,
-        max_part_size=None,
+            self,
+            write_intents_iterator,
+            file_name,
+            content_type=None,
+            file_info=None,
+            progress_listener=None,
+            recommended_upload_part_size=None,
+            continue_large_file_id=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            min_part_size=None,
+            max_part_size=None,
     ):
         """
         Creates a new file in this bucket using a stream of multiple remote or local sources.
@@ -678,20 +696,20 @@ class Bucket(metaclass=B2TraceMeta):
         )
 
     def _create_file(
-        self,
-        emerger_method,
-        write_intents_iterable,
-        file_name,
-        content_type=None,
-        file_info=None,
-        progress_listener=None,
-        recommended_upload_part_size=None,
-        continue_large_file_id=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        min_part_size=None,
-        max_part_size=None,
+            self,
+            emerger_method,
+            write_intents_iterable,
+            file_name,
+            content_type=None,
+            file_info=None,
+            progress_listener=None,
+            recommended_upload_part_size=None,
+            continue_large_file_id=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            min_part_size=None,
+            max_part_size=None,
     ):
         validate_b2_file_name(file_name)
         progress_listener = progress_listener or DoNothingProgressListener()
@@ -713,19 +731,19 @@ class Bucket(metaclass=B2TraceMeta):
         )
 
     def concatenate(
-        self,
-        outbound_sources,
-        file_name,
-        content_type=None,
-        file_info=None,
-        progress_listener=None,
-        recommended_upload_part_size=None,
-        continue_large_file_id=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        min_part_size=None,
-        max_part_size=None,
+            self,
+            outbound_sources,
+            file_name,
+            content_type=None,
+            file_info=None,
+            progress_listener=None,
+            recommended_upload_part_size=None,
+            continue_large_file_id=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            min_part_size=None,
+            max_part_size=None,
     ):
         """
         Creates a new file in this bucket by concatenating multiple remote or local sources.
@@ -766,17 +784,17 @@ class Bucket(metaclass=B2TraceMeta):
         )
 
     def concatenate_stream(
-        self,
-        outbound_sources_iterator,
-        file_name,
-        content_type=None,
-        file_info=None,
-        progress_listener=None,
-        recommended_upload_part_size=None,
-        continue_large_file_id=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            outbound_sources_iterator,
+            file_name,
+            content_type=None,
+            file_info=None,
+            progress_listener=None,
+            recommended_upload_part_size=None,
+            continue_large_file_id=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         """
         Creates a new file in this bucket by concatenating stream of multiple remote or local sources.
@@ -837,22 +855,22 @@ class Bucket(metaclass=B2TraceMeta):
         return self.api.file_version_factory.from_api_response(response)
 
     def copy(
-        self,
-        file_id,
-        new_file_name,
-        content_type=None,
-        file_info=None,
-        offset=0,
-        length=None,
-        progress_listener=None,
-        destination_encryption: Optional[EncryptionSetting] = None,
-        source_encryption: Optional[EncryptionSetting] = None,
-        source_file_info: Optional[dict] = None,
-        source_content_type: Optional[str] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        min_part_size=None,
-        max_part_size=None,
+            self,
+            file_id,
+            new_file_name,
+            content_type=None,
+            file_info=None,
+            offset=0,
+            length=None,
+            progress_listener=None,
+            destination_encryption: Optional[EncryptionSetting] = None,
+            source_encryption: Optional[EncryptionSetting] = None,
+            source_file_info: Optional[dict] = None,
+            source_content_type: Optional[str] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            min_part_size=None,
+            max_part_size=None,
     ):
         """
         Creates a new file in this bucket by (server-side) copying from an existing file.

--- a/b2sdk/cache.py
+++ b/b2sdk/cache.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from typing import Optional
 
 

--- a/b2sdk/encryption/setting.py
+++ b/b2sdk/encryption/setting.py
@@ -10,14 +10,29 @@
 
 import enum
 import logging
-from typing import Optional, Union
+from typing import (
+    Optional,
+    Union,
+)
 import urllib
 import urllib.parse
 
-from ..http_constants import SSE_C_KEY_ID_FILE_INFO_KEY_NAME, SSE_C_KEY_ID_HEADER
-from ..utils import b64_of_bytes, md5_of_bytes
-from .types import ENCRYPTION_MODES_WITH_MANDATORY_ALGORITHM, ENCRYPTION_MODES_WITH_MANDATORY_KEY
-from .types import EncryptionAlgorithm, EncryptionMode
+from ..http_constants import (
+    SSE_C_KEY_ID_FILE_INFO_KEY_NAME,
+    SSE_C_KEY_ID_HEADER,
+)
+from ..utils import (
+    b64_of_bytes,
+    md5_of_bytes,
+)
+from .types import (
+    ENCRYPTION_MODES_WITH_MANDATORY_ALGORITHM,
+    ENCRYPTION_MODES_WITH_MANDATORY_KEY,
+)
+from .types import (
+    EncryptionAlgorithm,
+    EncryptionMode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -88,10 +103,10 @@ class EncryptionSetting:
     """
 
     def __init__(
-        self,
-        mode: EncryptionMode,
-        algorithm: EncryptionAlgorithm = None,
-        key: EncryptionKey = None,
+            self,
+            mode: EncryptionMode,
+            algorithm: EncryptionAlgorithm = None,
+            key: EncryptionKey = None,
     ):
         """
         :param b2sdk.v2.EncryptionMode mode: encryption mode
@@ -149,7 +164,9 @@ class EncryptionSetting:
                 'mode': 'none'
             }
         """
-        result = {'mode': self.mode.value}
+        result = {
+            'mode': self.mode.value
+        }
         if self.algorithm is not None:
             result['algorithm'] = self.algorithm.value
         if self.mode == EncryptionMode.SSE_C:
@@ -302,7 +319,9 @@ class EncryptionSettingFactory:
         """
         default_sse = bucket_dict.get(
             'defaultServerSideEncryption',
-            {'isClientAuthorizedToRead': False},
+            {
+                'isClientAuthorizedToRead': False
+            },
         )
 
         if not default_sse['isClientAuthorizedToRead']:
@@ -346,7 +365,7 @@ class EncryptionSettingFactory:
         return EncryptionSetting(EncryptionMode.NONE)
 
 
-SSE_NONE = EncryptionSetting(mode=EncryptionMode.NONE,)
+SSE_NONE = EncryptionSetting(mode=EncryptionMode.NONE, )
 """
 Commonly used "no encryption" setting
 """

--- a/b2sdk/encryption/types.py
+++ b/b2sdk/encryption/types.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from enum import Enum, unique
+from enum import (
+    Enum,
+    unique,
+)
 
 
 @unique
@@ -33,7 +36,7 @@ class EncryptionMode(Enum):
     SSE_B2 = 'SSE-B2'  #: server-side encryption with key maintained by B2
     SSE_C = 'SSE-C'  #: server-side encryption with key provided by the client
 
-    #CLIENT = 'CLIENT'  #: client-side encryption
+    # CLIENT = 'CLIENT'  #: client-side encryption
 
     def can_be_set_as_bucket_default(self):
         return self in BUCKET_DEFAULT_ENCRYPTION_MODES

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -13,9 +13,16 @@ from abc import ABCMeta
 import logging
 import re
 import warnings
-from typing import Any, Dict, Optional
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
 
-from .utils import camelcase_to_underscore, trace_call
+from .utils import (
+    camelcase_to_underscore,
+    trace_call,
+)
 
 UPLOAD_TOKEN_USED_CONCURRENTLY_ERROR_MESSAGE_RE = re.compile(
     r'^more than one upload using auth token (?P<token>[^)]+)$'
@@ -535,11 +542,11 @@ class EnablingFileLockOnRestrictedBucket(B2Error):
 
 @trace_call(logger)
 def interpret_b2_error(
-    status: int,
-    code: Optional[str],
-    message: Optional[str],
-    response_headers: Dict[str, Any],
-    post_params: Optional[Dict[str, Any]] = None
+        status: int,
+        code: Optional[str],
+        message: Optional[str],
+        response_headers: Dict[str, Any],
+        post_params: Optional[Dict[str, Any]] = None
 ) -> B2Error:
     post_params = post_params or {}
     if status == 400 and code == "already_hidden":
@@ -547,8 +554,8 @@ def interpret_b2_error(
     elif status == 400 and code == 'bad_json':
         return BadJson(message)
     elif (
-        (status == 400 and code in ("no_such_file", "file_not_present")) or
-        (status == 404 and code == "not_found")
+            (status == 400 and code in ("no_such_file", "file_not_present")) or
+            (status == 404 and code == "not_found")
     ):
         # hide_file returns 400 and "no_such_file"
         # delete_file_version returns 400 and "file_not_present"

--- a/b2sdk/file_lock.py
+++ b/b2sdk/file_lock.py
@@ -55,7 +55,9 @@ class RetentionPeriod:
             }
         """
         assert period_dict['unit'] in cls.KNOWN_UNITS
-        return cls(**{period_dict['unit']: period_dict['duration']})
+        return cls(**{
+            period_dict['unit']: period_dict['duration']
+        })
 
     def as_dict(self):
         return {
@@ -123,7 +125,7 @@ class FileRetentionSetting:
 
     @classmethod
     def from_file_retention_value_dict(
-        cls, file_retention_value_dict: dict
+            cls, file_retention_value_dict: dict
     ) -> 'FileRetentionSetting':
 
         mode = file_retention_value_dict['mode']
@@ -303,9 +305,9 @@ class FileLockConfiguration:
     file retention"""
 
     def __init__(
-        self,
-        default_retention: BucketRetentionSetting,
-        is_file_lock_enabled: Optional[bool],
+            self,
+            default_retention: BucketRetentionSetting,
+            is_file_lock_enabled: Optional[bool],
     ):
         self.default_retention = default_retention
         self.is_file_lock_enabled = is_file_lock_enabled

--- a/b2sdk/file_version.py
+++ b/b2sdk/file_version.py
@@ -8,14 +8,30 @@
 #
 ######################################################################
 
-from typing import Dict, Optional, Union, Tuple, TYPE_CHECKING
+from typing import (
+    Dict,
+    Optional,
+    Union,
+    Tuple,
+    TYPE_CHECKING,
+)
 import re
 from copy import deepcopy
 
-from .encryption.setting import EncryptionSetting, EncryptionSettingFactory
+from .encryption.setting import (
+    EncryptionSetting,
+    EncryptionSettingFactory,
+)
 from .replication.types import ReplicationStatus
-from .http_constants import FILE_INFO_HEADER_PREFIX_LOWER, SRC_LAST_MODIFIED_MILLIS
-from .file_lock import FileRetentionSetting, LegalHold, NO_RETENTION_FILE_SETTING
+from .http_constants import (
+    FILE_INFO_HEADER_PREFIX_LOWER,
+    SRC_LAST_MODIFIED_MILLIS,
+)
+from .file_lock import (
+    FileRetentionSetting,
+    LegalHold,
+    NO_RETENTION_FILE_SETTING,
+)
 from .progress import AbstractProgressListener
 from .utils.range_ import Range
 from .utils import b2_url_decode
@@ -58,19 +74,19 @@ class BaseFileVersion:
     }
 
     def __init__(
-        self,
-        api: 'B2Api',
-        id_: str,
-        file_name: str,
-        size: int,
-        content_type: Optional[str],
-        content_sha1: Optional[str],
-        file_info: Dict[str, str],
-        upload_timestamp: int,
-        server_side_encryption: EncryptionSetting,
-        file_retention: FileRetentionSetting = NO_RETENTION_FILE_SETTING,
-        legal_hold: LegalHold = LegalHold.UNSET,
-        replication_status: Optional[ReplicationStatus] = None,
+            self,
+            api: 'B2Api',
+            id_: str,
+            file_name: str,
+            size: int,
+            content_type: Optional[str],
+            content_sha1: Optional[str],
+            file_info: Dict[str, str],
+            upload_timestamp: int,
+            server_side_encryption: EncryptionSetting,
+            file_retention: FileRetentionSetting = NO_RETENTION_FILE_SETTING,
+            legal_hold: LegalHold = LegalHold.UNSET,
+            replication_status: Optional[ReplicationStatus] = None,
     ):
         self.api = api
         self.id_ = id_
@@ -179,9 +195,9 @@ class BaseFileVersion:
         return self._clone(legal_hold=legal_hold)
 
     def update_retention(
-        self,
-        file_retention: FileRetentionSetting,
-        bypass_governance: bool = False,
+            self,
+            file_retention: FileRetentionSetting,
+            bypass_governance: bool = False,
     ) -> 'BaseFileVersion':
         file_retention = self.api.update_file_retention(
             self.id_, self.file_name, file_retention, bypass_governance
@@ -222,23 +238,23 @@ class FileVersion(BaseFileVersion):
     ADVANCED_HEADERS_LIMIT = 2048
 
     def __init__(
-        self,
-        api: 'B2Api',
-        id_: str,
-        file_name: str,
-        size: Union[int, None, str],
-        content_type: Optional[str],
-        content_sha1: Optional[str],
-        file_info: Dict[str, str],
-        upload_timestamp: int,
-        account_id: str,
-        bucket_id: str,
-        action: str,
-        content_md5: Optional[str],
-        server_side_encryption: EncryptionSetting,
-        file_retention: FileRetentionSetting = NO_RETENTION_FILE_SETTING,
-        legal_hold: LegalHold = LegalHold.UNSET,
-        replication_status: Optional[ReplicationStatus] = None,
+            self,
+            api: 'B2Api',
+            id_: str,
+            file_name: str,
+            size: Union[int, None, str],
+            content_type: Optional[str],
+            content_sha1: Optional[str],
+            file_info: Dict[str, str],
+            upload_timestamp: int,
+            account_id: str,
+            bucket_id: str,
+            action: str,
+            content_md5: Optional[str],
+            server_side_encryption: EncryptionSetting,
+            file_retention: FileRetentionSetting = NO_RETENTION_FILE_SETTING,
+            legal_hold: LegalHold = LegalHold.UNSET,
+            replication_status: Optional[ReplicationStatus] = None,
     ):
         self.account_id = account_id
         self.bucket_id = bucket_id
@@ -292,10 +308,10 @@ class FileVersion(BaseFileVersion):
         return self.api.get_file_info(self.id_)
 
     def download(
-        self,
-        progress_listener: Optional[AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            progress_listener: Optional[AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[EncryptionSetting] = None,
     ) -> 'DownloadedFile':
         return self.api.download_file_by_id(
             self.id_,
@@ -364,26 +380,26 @@ class DownloadVersion(BaseFileVersion):
     ]
 
     def __init__(
-        self,
-        api: 'B2Api',
-        id_: str,
-        file_name: str,
-        size: int,
-        content_type: Optional[str],
-        content_sha1: Optional[str],
-        file_info: Dict[str, str],
-        upload_timestamp: int,
-        server_side_encryption: EncryptionSetting,
-        range_: Range,
-        content_disposition: Optional[str],
-        content_length: int,
-        content_language: Optional[str],
-        expires,
-        cache_control,
-        content_encoding: Optional[str],
-        file_retention: FileRetentionSetting = NO_RETENTION_FILE_SETTING,
-        legal_hold: LegalHold = LegalHold.UNSET,
-        replication_status: Optional[ReplicationStatus] = None,
+            self,
+            api: 'B2Api',
+            id_: str,
+            file_name: str,
+            size: int,
+            content_type: Optional[str],
+            content_sha1: Optional[str],
+            file_info: Dict[str, str],
+            upload_timestamp: int,
+            server_side_encryption: EncryptionSetting,
+            range_: Range,
+            content_disposition: Optional[str],
+            content_length: int,
+            content_language: Optional[str],
+            expires,
+            cache_control,
+            content_encoding: Optional[str],
+            file_retention: FileRetentionSetting = NO_RETENTION_FILE_SETTING,
+            legal_hold: LegalHold = LegalHold.UNSET,
+            replication_status: Optional[ReplicationStatus] = None,
     ):
         self.range_ = range_
         self.content_disposition = content_disposition
@@ -589,7 +605,11 @@ class FileIdAndName:
 
     def as_dict(self):
         """ represents the object as a dict which looks almost exactly like the raw api output for delete_file_version """
-        return {'action': 'delete', 'fileId': self.file_id, 'fileName': self.file_name}
+        return {
+            'action': 'delete',
+            'fileId': self.file_id,
+            'fileName': self.file_name
+        }
 
     def __eq__(self, other):
         return (self.file_id == other.file_id and self.file_name == other.file_name)

--- a/b2sdk/included_sources.py
+++ b/b2sdk/included_sources.py
@@ -12,7 +12,10 @@
 # B2 Command Line Tool for printing, for legal compliance reasons
 
 import dataclasses
-from typing import Dict, List
+from typing import (
+    Dict,
+    List,
+)
 
 _included_sources: List['IncludedSourceMeta'] = []
 

--- a/b2sdk/large_file/services.py
+++ b/b2sdk/large_file/services.py
@@ -11,7 +11,10 @@
 from typing import Optional
 
 from b2sdk.encryption.setting import EncryptionSetting
-from b2sdk.file_lock import FileRetentionSetting, LegalHold
+from b2sdk.file_lock import (
+    FileRetentionSetting,
+    LegalHold,
+)
 from b2sdk.file_version import FileIdAndName
 from b2sdk.large_file.part import PartFactory
 from b2sdk.large_file.unfinished_large_file import UnfinishedLargeFile
@@ -40,7 +43,7 @@ class LargeFileServices:
                 break
 
     def list_unfinished_large_files(
-        self, bucket_id, start_file_id=None, batch_size=None, prefix=None
+            self, bucket_id, start_file_id=None, batch_size=None, prefix=None
     ):
         """
         A generator that yields an :py:class:`b2sdk.v2.UnfinishedLargeFile` for each
@@ -79,14 +82,14 @@ class LargeFileServices:
         return unfinished_large_file
 
     def start_large_file(
-        self,
-        bucket_id,
-        file_name,
-        content_type=None,
-        file_info=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            bucket_id,
+            file_name,
+            content_type=None,
+            file_info=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         """
         Start a large file transfer.

--- a/b2sdk/large_file/unfinished_large_file.py
+++ b/b2sdk/large_file/unfinished_large_file.py
@@ -9,7 +9,10 @@
 ######################################################################
 
 from b2sdk.encryption.setting import EncryptionSettingFactory
-from b2sdk.file_lock import FileRetentionSetting, LegalHold
+from b2sdk.file_lock import (
+    FileRetentionSetting,
+    LegalHold,
+)
 
 
 class UnfinishedLargeFile:

--- a/b2sdk/progress.py
+++ b/b2sdk/progress.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 import time
 
 try:
@@ -58,7 +61,7 @@ class AbstractProgressListener(metaclass=ABCMeta):
         Must be called when you're done with the listener.
         In well-structured code, should be called only once.
         """
-        #import traceback, sys; traceback.print_stack(file=sys.stdout)
+        # import traceback, sys; traceback.print_stack(file=sys.stdout)
         assert self._closed is False, 'progress listener was closed twice! uncomment the line above to debug this'
         self._closed = True
 

--- a/b2sdk/raw_api.py
+++ b/b2sdk/raw_api.py
@@ -10,15 +10,41 @@
 
 import base64
 import re
-from abc import ABCMeta, abstractmethod
-from enum import Enum, unique
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
+from enum import (
+    Enum,
+    unique,
+)
 from logging import getLogger
-from typing import Any, Dict, Optional
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
 
-from .exception import FileOrBucketNotFound, ResourceNotFound, UnusableFileName, InvalidMetadataDirective, WrongEncryptionModeForBucketDefault, AccessDenied, SSECKeyError, RetentionWriteError
-from .encryption.setting import EncryptionMode, EncryptionSetting
+from .exception import (
+    FileOrBucketNotFound,
+    ResourceNotFound,
+    UnusableFileName,
+    InvalidMetadataDirective,
+    WrongEncryptionModeForBucketDefault,
+    AccessDenied,
+    SSECKeyError,
+    RetentionWriteError,
+)
+from .encryption.setting import (
+    EncryptionMode,
+    EncryptionSetting,
+)
 from .replication.setting import ReplicationConfiguration
-from .file_lock import BucketRetentionSetting, FileRetentionSetting, LegalHold
+from .file_lock import (
+    BucketRetentionSetting,
+    FileRetentionSetting,
+    LegalHold,
+)
 from .utils import b2_url_encode
 from b2sdk.http_constants import FILE_INFO_HEADER_PREFIX
 
@@ -85,68 +111,68 @@ class AbstractRawApi(metaclass=ABCMeta):
 
     @abstractmethod
     def copy_file(
-        self,
-        api_url,
-        account_auth_token,
-        source_file_id,
-        new_file_name,
-        bytes_range=None,
-        metadata_directive=None,
-        content_type=None,
-        file_info=None,
-        destination_bucket_id=None,
-        destination_server_side_encryption: Optional[EncryptionSetting] = None,
-        source_server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            api_url,
+            account_auth_token,
+            source_file_id,
+            new_file_name,
+            bytes_range=None,
+            metadata_directive=None,
+            content_type=None,
+            file_info=None,
+            destination_bucket_id=None,
+            destination_server_side_encryption: Optional[EncryptionSetting] = None,
+            source_server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         pass
 
     @abstractmethod
     def copy_part(
-        self,
-        api_url,
-        account_auth_token,
-        source_file_id,
-        large_file_id,
-        part_number,
-        bytes_range=None,
-        destination_server_side_encryption: Optional[EncryptionSetting] = None,
-        source_server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            api_url,
+            account_auth_token,
+            source_file_id,
+            large_file_id,
+            part_number,
+            bytes_range=None,
+            destination_server_side_encryption: Optional[EncryptionSetting] = None,
+            source_server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         pass
 
     @abstractmethod
     def create_bucket(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        bucket_name,
-        bucket_type,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        is_file_lock_enabled: Optional[bool] = None,
-        replication: Optional[ReplicationConfiguration] = None,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            bucket_name,
+            bucket_type,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            is_file_lock_enabled: Optional[bool] = None,
+            replication: Optional[ReplicationConfiguration] = None,
     ):
         pass
 
     @abstractmethod
     def create_key(
-        self, api_url, account_auth_token, account_id, capabilities, key_name,
-        valid_duration_seconds, bucket_id, name_prefix
+            self, api_url, account_auth_token, account_id, capabilities, key_name,
+            valid_duration_seconds, bucket_id, name_prefix
     ):
         pass
 
     @abstractmethod
     def download_file_from_url(
-        self,
-        account_auth_token_or_none,
-        url,
-        range_=None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            account_auth_token_or_none,
+            url,
+            range_=None,
+            encryption: Optional[EncryptionSetting] = None,
     ):
         pass
 
@@ -168,7 +194,7 @@ class AbstractRawApi(metaclass=ABCMeta):
 
     @abstractmethod
     def get_download_authorization(
-        self, api_url, account_auth_token, bucket_id, file_name_prefix, valid_duration_in_seconds
+            self, api_url, account_auth_token, bucket_id, file_name_prefix, valid_duration_in_seconds
     ):
         pass
 
@@ -179,7 +205,7 @@ class AbstractRawApi(metaclass=ABCMeta):
 
     @abstractmethod
     def get_file_info_by_name(
-        self, download_url: str, account_auth_token: str, bucket_name: str, file_name: str
+            self, download_url: str, account_auth_token: str, bucket_name: str, file_name: str
     ) -> Dict[str, Any]:
         pass
 
@@ -197,48 +223,48 @@ class AbstractRawApi(metaclass=ABCMeta):
 
     @abstractmethod
     def list_buckets(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        bucket_id=None,
-        bucket_name=None,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            bucket_id=None,
+            bucket_name=None,
     ):
         pass
 
     @abstractmethod
     def list_file_names(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_name=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_name=None,
+            max_file_count=None,
+            prefix=None,
     ):
         pass
 
     @abstractmethod
     def list_file_versions(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_name=None,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_name=None,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None,
     ):
         pass
 
     @abstractmethod
     def list_keys(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        max_key_count=None,
-        start_application_key_id=None
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            max_key_count=None,
+            start_application_key_id=None
     ):
         pass
 
@@ -248,74 +274,74 @@ class AbstractRawApi(metaclass=ABCMeta):
 
     @abstractmethod
     def list_unfinished_large_files(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None,
     ):
         pass
 
     @abstractmethod
     def start_large_file(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        file_name,
-        content_type,
-        file_info,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            file_name,
+            content_type,
+            file_info,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         pass
 
     @abstractmethod
     def update_bucket(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        bucket_id,
-        bucket_type=None,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        if_revision_is=None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        default_retention: Optional[BucketRetentionSetting] = None,
-        replication: Optional[ReplicationConfiguration] = None,
-        is_file_lock_enabled: Optional[bool] = None,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            bucket_id,
+            bucket_type=None,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            if_revision_is=None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            default_retention: Optional[BucketRetentionSetting] = None,
+            replication: Optional[ReplicationConfiguration] = None,
+            is_file_lock_enabled: Optional[bool] = None,
     ):
         pass
 
     @abstractmethod
     def update_file_retention(
-        self,
-        api_url,
-        account_auth_token,
-        file_id,
-        file_name,
-        file_retention: FileRetentionSetting,
-        bypass_governance: bool = False,
+            self,
+            api_url,
+            account_auth_token,
+            file_id,
+            file_name,
+            file_retention: FileRetentionSetting,
+            bypass_governance: bool = False,
     ):
         pass
 
     @classmethod
     def get_upload_file_headers(
-        cls,
-        upload_auth_token: str,
-        file_name: str,
-        content_length: int,
-        content_type: str,
-        content_sha1: str,
-        file_infos: dict,
-        server_side_encryption: Optional[EncryptionSetting],
-        file_retention: Optional[FileRetentionSetting],
-        legal_hold: Optional[LegalHold],
+            cls,
+            upload_auth_token: str,
+            file_name: str,
+            content_length: int,
+            content_type: str,
+            content_sha1: str,
+            file_infos: dict,
+            server_side_encryption: Optional[EncryptionSetting],
+            file_retention: Optional[FileRetentionSetting],
+            legal_hold: Optional[LegalHold],
     ) -> dict:
         headers = {
             'Authorization': upload_auth_token,
@@ -342,31 +368,31 @@ class AbstractRawApi(metaclass=ABCMeta):
 
     @abstractmethod
     def upload_file(
-        self,
-        upload_url,
-        upload_auth_token,
-        file_name,
-        content_length,
-        content_type,
-        content_sha1,
-        file_infos,
-        data_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            upload_url,
+            upload_auth_token,
+            file_name,
+            content_length,
+            content_type,
+            content_sha1,
+            file_infos,
+            data_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         pass
 
     @abstractmethod
     def upload_part(
-        self,
-        upload_url,
-        upload_auth_token,
-        part_number,
-        content_length,
-        sha1_sum,
-        input_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            upload_url,
+            upload_auth_token,
+            part_number,
+            content_length,
+            sha1_sum,
+            input_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         pass
 
@@ -409,7 +435,9 @@ class B2RawHTTPApi(AbstractRawApi):
         :rtype: dict
         """
         url = '%s/b2api/%s/%s' % (base_url, API_VERSION, api_name)
-        headers = {'Authorization': auth}
+        headers = {
+            'Authorization': auth
+        }
         return self.b2_http.post_json_return_json(url, headers, params)
 
     def authorize_account(self, realm_url, application_key_id, application_key):
@@ -422,18 +450,18 @@ class B2RawHTTPApi(AbstractRawApi):
         return self._post_json(api_url, 'b2_cancel_large_file', account_auth_token, fileId=file_id)
 
     def create_bucket(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        bucket_name,
-        bucket_type,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        is_file_lock_enabled: Optional[bool] = None,
-        replication: Optional[ReplicationConfiguration] = None,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            bucket_name,
+            bucket_type,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            is_file_lock_enabled: Optional[bool] = None,
+            replication: Optional[ReplicationConfiguration] = None,
     ):
         kwargs = dict(
             accountId=account_id,
@@ -450,7 +478,7 @@ class B2RawHTTPApi(AbstractRawApi):
             if not default_server_side_encryption.mode.can_be_set_as_bucket_default():
                 raise WrongEncryptionModeForBucketDefault(default_server_side_encryption.mode)
             kwargs['defaultServerSideEncryption'
-                  ] = default_server_side_encryption.serialize_to_json_for_request()
+            ] = default_server_side_encryption.serialize_to_json_for_request()
         if is_file_lock_enabled is not None:
             kwargs['fileLockEnabled'] = is_file_lock_enabled
         if replication is not None:
@@ -463,8 +491,8 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def create_key(
-        self, api_url, account_auth_token, account_id, capabilities, key_name,
-        valid_duration_seconds, bucket_id, name_prefix
+            self, api_url, account_auth_token, account_id, capabilities, key_name,
+            valid_duration_seconds, bucket_id, name_prefix
     ):
         return self._post_json(
             api_url,
@@ -505,11 +533,11 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def download_file_from_url(
-        self,
-        account_auth_token_or_none,
-        url,
-        range_=None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            account_auth_token_or_none,
+            url,
+            range_=None,
+            encryption: Optional[EncryptionSetting] = None,
     ):
         """
         Issue a streaming request for download of a file, potentially authorized.
@@ -546,7 +574,7 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def get_download_authorization(
-        self, api_url, account_auth_token, bucket_id, file_name_prefix, valid_duration_in_seconds
+            self, api_url, account_auth_token, bucket_id, file_name_prefix, valid_duration_in_seconds
     ):
         return self._post_json(
             api_url,
@@ -562,12 +590,14 @@ class B2RawHTTPApi(AbstractRawApi):
         return self._post_json(api_url, 'b2_get_file_info', account_auth_token, fileId=file_id)
 
     def get_file_info_by_name(
-        self, download_url: str, account_auth_token: str, bucket_name: str, file_name: str
+            self, download_url: str, account_auth_token: str, bucket_name: str, file_name: str
     ) -> Dict[str, Any]:
         download_url = self.get_download_url_by_name(download_url, bucket_name, file_name)
         try:
             response = self.b2_http.head_content(
-                download_url, headers={"Authorization": account_auth_token}
+                download_url, headers={
+                    "Authorization": account_auth_token
+                }
             )
             return response.headers
         except ResourceNotFound:
@@ -588,12 +618,12 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def list_buckets(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        bucket_id=None,
-        bucket_name=None,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            bucket_id=None,
+            bucket_name=None,
     ):
         return self._post_json(
             api_url,
@@ -606,13 +636,13 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def list_file_names(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_name=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_name=None,
+            max_file_count=None,
+            prefix=None,
     ):
         return self._post_json(
             api_url,
@@ -625,14 +655,14 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def list_file_versions(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_name=None,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_name=None,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None,
     ):
         return self._post_json(
             api_url,
@@ -646,12 +676,12 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def list_keys(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        max_key_count=None,
-        start_application_key_id=None
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            max_key_count=None,
+            start_application_key_id=None
     ):
         return self._post_json(
             api_url,
@@ -673,13 +703,13 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def list_unfinished_large_files(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None,
     ):
         return self._post_json(
             api_url,
@@ -692,16 +722,16 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def start_large_file(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        file_name,
-        content_type,
-        file_info,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            file_name,
+            content_type,
+            file_info,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         kwargs = {}
         if server_side_encryption is not None:
@@ -728,20 +758,20 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def update_bucket(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        bucket_id,
-        bucket_type=None,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        if_revision_is=None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        default_retention: Optional[BucketRetentionSetting] = None,
-        replication: Optional[ReplicationConfiguration] = None,
-        is_file_lock_enabled: Optional[bool] = None,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            bucket_id,
+            bucket_type=None,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            if_revision_is=None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            default_retention: Optional[BucketRetentionSetting] = None,
+            replication: Optional[ReplicationConfiguration] = None,
+            is_file_lock_enabled: Optional[bool] = None,
     ):
         kwargs = {}
         if if_revision_is is not None:
@@ -758,7 +788,7 @@ class B2RawHTTPApi(AbstractRawApi):
             if not default_server_side_encryption.mode.can_be_set_as_bucket_default():
                 raise WrongEncryptionModeForBucketDefault(default_server_side_encryption.mode)
             kwargs['defaultServerSideEncryption'
-                  ] = default_server_side_encryption.serialize_to_json_for_request()
+            ] = default_server_side_encryption.serialize_to_json_for_request()
         if default_retention is not None:
             kwargs['defaultRetention'] = default_retention.serialize_to_json_for_request()
         if replication is not None:
@@ -778,13 +808,13 @@ class B2RawHTTPApi(AbstractRawApi):
         )
 
     def update_file_retention(
-        self,
-        api_url,
-        account_auth_token,
-        file_id,
-        file_name,
-        file_retention: FileRetentionSetting,
-        bypass_governance: bool = False,
+            self,
+            api_url,
+            account_auth_token,
+            file_id,
+            file_name,
+            file_retention: FileRetentionSetting,
+            bypass_governance: bool = False,
     ):
         kwargs = {}
         kwargs['fileRetention'] = file_retention.serialize_to_json_for_request()
@@ -802,12 +832,12 @@ class B2RawHTTPApi(AbstractRawApi):
             raise RetentionWriteError()
 
     def update_file_legal_hold(
-        self,
-        api_url,
-        account_auth_token,
-        file_id,
-        file_name,
-        legal_hold: LegalHold,
+            self,
+            api_url,
+            account_auth_token,
+            file_id,
+            file_name,
+            legal_hold: LegalHold,
     ):
         try:
             return self._post_json(
@@ -869,18 +899,18 @@ class B2RawHTTPApi(AbstractRawApi):
             raise UnusableFileName("Filename segment too long (maximum 250 bytes in utf-8).")
 
     def upload_file(
-        self,
-        upload_url,
-        upload_auth_token,
-        file_name,
-        content_length,
-        content_type,
-        content_sha1,
-        file_infos,
-        data_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            upload_url,
+            upload_auth_token,
+            file_name,
+            content_length,
+            content_type,
+            content_sha1,
+            file_infos,
+            data_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         """
         Upload one, small file to b2.
@@ -911,14 +941,14 @@ class B2RawHTTPApi(AbstractRawApi):
         return self.b2_http.post_content_return_json(upload_url, headers, data_stream)
 
     def upload_part(
-        self,
-        upload_url,
-        upload_auth_token,
-        part_number,
-        content_length,
-        content_sha1,
-        data_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            upload_url,
+            upload_auth_token,
+            part_number,
+            content_length,
+            content_sha1,
+            data_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         headers = {
             'Authorization': upload_auth_token,
@@ -935,20 +965,20 @@ class B2RawHTTPApi(AbstractRawApi):
         return self.b2_http.post_content_return_json(upload_url, headers, data_stream)
 
     def copy_file(
-        self,
-        api_url,
-        account_auth_token,
-        source_file_id,
-        new_file_name,
-        bytes_range=None,
-        metadata_directive=None,
-        content_type=None,
-        file_info=None,
-        destination_bucket_id=None,
-        destination_server_side_encryption: Optional[EncryptionSetting] = None,
-        source_server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            api_url,
+            account_auth_token,
+            source_file_id,
+            new_file_name,
+            bytes_range=None,
+            metadata_directive=None,
+            content_type=None,
+            file_info=None,
+            destination_bucket_id=None,
+            destination_server_side_encryption: Optional[EncryptionSetting] = None,
+            source_server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         kwargs = {}
         if bytes_range is not None:
@@ -959,7 +989,7 @@ class B2RawHTTPApi(AbstractRawApi):
         if metadata_directive is not None:
             assert metadata_directive in tuple(MetadataDirectiveMode)
             if metadata_directive is MetadataDirectiveMode.COPY and (
-                content_type is not None or file_info is not None
+                    content_type is not None or file_info is not None
             ):
                 raise InvalidMetadataDirective(
                     'content_type and file_info should be None when metadata_directive is COPY'
@@ -981,11 +1011,11 @@ class B2RawHTTPApi(AbstractRawApi):
                 EncryptionMode.NONE, EncryptionMode.SSE_B2, EncryptionMode.SSE_C
             )
             kwargs['destinationServerSideEncryption'
-                  ] = destination_server_side_encryption.serialize_to_json_for_request()
+            ] = destination_server_side_encryption.serialize_to_json_for_request()
         if source_server_side_encryption is not None:
             assert source_server_side_encryption.mode == EncryptionMode.SSE_C
             kwargs['sourceServerSideEncryption'
-                  ] = source_server_side_encryption.serialize_to_json_for_request()
+            ] = source_server_side_encryption.serialize_to_json_for_request()
 
         if legal_hold is not None:
             kwargs['legalHold'] = legal_hold.to_server()
@@ -1006,15 +1036,15 @@ class B2RawHTTPApi(AbstractRawApi):
             raise SSECKeyError()
 
     def copy_part(
-        self,
-        api_url,
-        account_auth_token,
-        source_file_id,
-        large_file_id,
-        part_number,
-        bytes_range=None,
-        destination_server_side_encryption: Optional[EncryptionSetting] = None,
-        source_server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            api_url,
+            account_auth_token,
+            source_file_id,
+            large_file_id,
+            part_number,
+            bytes_range=None,
+            destination_server_side_encryption: Optional[EncryptionSetting] = None,
+            source_server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         kwargs = {}
         if bytes_range is not None:
@@ -1026,13 +1056,13 @@ class B2RawHTTPApi(AbstractRawApi):
                 EncryptionMode.NONE, EncryptionMode.SSE_B2, EncryptionMode.SSE_C
             )
             kwargs['destinationServerSideEncryption'
-                  ] = destination_server_side_encryption.serialize_to_json_for_request()
+            ] = destination_server_side_encryption.serialize_to_json_for_request()
         if source_server_side_encryption is not None:
             assert source_server_side_encryption.mode in (
                 EncryptionMode.NONE, EncryptionMode.SSE_B2, EncryptionMode.SSE_C
             )
             kwargs['sourceServerSideEncryption'
-                  ] = source_server_side_encryption.serialize_to_json_for_request()
+            ] = source_server_side_encryption.serialize_to_json_for_request()
         try:
             return self._post_json(
                 api_url,

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -19,12 +19,18 @@ import time
 from contextlib import contextmanager
 from typing import Optional
 
-from b2sdk.http_constants import FILE_INFO_HEADER_PREFIX, HEX_DIGITS_AT_END
+from b2sdk.http_constants import (
+    FILE_INFO_HEADER_PREFIX,
+    HEX_DIGITS_AT_END,
+)
 from b2sdk.replication.setting import ReplicationConfiguration
 from requests.structures import CaseInsensitiveDict
 
 from .b2http import ResponseContextManager
-from .encryption.setting import EncryptionMode, EncryptionSetting
+from .encryption.setting import (
+    EncryptionMode,
+    EncryptionSetting,
+)
 from .replication.types import ReplicationStatus
 from .exception import (
     BadJson,
@@ -54,9 +60,18 @@ from .file_lock import (
     LegalHold,
 )
 from .file_version import UNVERIFIED_CHECKSUM_PREFIX
-from .raw_api import ALL_CAPABILITIES, AbstractRawApi, MetadataDirectiveMode
+from .raw_api import (
+    ALL_CAPABILITIES,
+    AbstractRawApi,
+    MetadataDirectiveMode,
+)
 from .stream.hashing import StreamWithHash
-from .utils import ConcurrentUsedAuthTokenGuard, b2_url_decode, b2_url_encode, hex_sha1_of_bytes
+from .utils import (
+    ConcurrentUsedAuthTokenGuard,
+    b2_url_decode,
+    b2_url_encode,
+    hex_sha1_of_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +96,8 @@ class KeySimulator:
     """
 
     def __init__(
-        self, account_id, name, application_key_id, key, capabilities, expiration_timestamp_or_none,
-        bucket_id_or_none, bucket_name_or_none, name_prefix_or_none
+            self, account_id, name, application_key_id, key, capabilities, expiration_timestamp_or_none,
+            bucket_id_or_none, bucket_name_or_none, name_prefix_or_none
     ):
         self.name = name
         self.account_id = account_id
@@ -100,7 +115,7 @@ class KeySimulator:
             applicationKeyId=self.application_key_id,
             capabilities=self.capabilities,
             expirationTimestamp=self.expiration_timestamp_or_none and
-            self.expiration_timestamp_or_none * 1000,
+                                self.expiration_timestamp_or_none * 1000,
             keyName=self.name,
             namePrefix=self.name_prefix_or_none,
         )
@@ -158,22 +173,22 @@ class FileSimulator:
     }
 
     def __init__(
-        self,
-        account_id,
-        bucket,
-        file_id,
-        action,
-        name,
-        content_type,
-        content_sha1,
-        file_info,
-        data_bytes,
-        upload_timestamp,
-        range_=None,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: LegalHold = LegalHold.UNSET,
-        replication_status: Optional[ReplicationStatus] = None,
+            self,
+            account_id,
+            bucket,
+            file_id,
+            action,
+            name,
+            content_type,
+            content_sha1,
+            file_info,
+            data_bytes,
+            upload_timestamp,
+            range_=None,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: LegalHold = LegalHold.UNSET,
+            replication_status: Optional[ReplicationStatus] = None,
     ):
         if action == 'hide':
             assert server_side_encryption is None
@@ -266,9 +281,9 @@ class FileSimulator:
                 headers['X-Bz-Server-Side-Encryption'] = self.server_side_encryption.algorithm.value
             elif self.server_side_encryption.mode == EncryptionMode.SSE_C:
                 headers['X-Bz-Server-Side-Encryption-Customer-Algorithm'
-                       ] = self.server_side_encryption.algorithm.value
+                ] = self.server_side_encryption.algorithm.value
                 headers['X-Bz-Server-Side-Encryption-Customer-Key-Md5'
-                       ] = self.server_side_encryption.key.key_md5()
+                ] = self.server_side_encryption.key.key_md5()
             elif self.server_side_encryption.mode in (EncryptionMode.NONE, EncryptionMode.UNKNOWN):
                 pass
             else:
@@ -298,7 +313,7 @@ class FileSimulator:
         )  # yapf: disable
         if self.server_side_encryption is not None:
             result['serverSideEncryption'
-                  ] = self.server_side_encryption.serialize_to_json_for_request()
+            ] = self.server_side_encryption.serialize_to_json_for_request()
         result['fileRetention'] = self._file_retention_dict(account_auth_token)
         result['legalHold'] = self._legal_hold_dict(account_auth_token)
         return result
@@ -319,7 +334,7 @@ class FileSimulator:
         )  # yapf: disable
         if self.server_side_encryption is not None:
             result['serverSideEncryption'
-                  ] = self.server_side_encryption.serialize_to_json_for_request()
+            ] = self.server_side_encryption.serialize_to_json_for_request()
         result['fileRetention'] = self._file_retention_dict(account_auth_token)
         result['legalHold'] = self._legal_hold_dict(account_auth_token)
         return result
@@ -343,7 +358,7 @@ class FileSimulator:
         )  # yapf: disable
         if self.server_side_encryption is not None:
             result['serverSideEncryption'
-                  ] = self.server_side_encryption.serialize_to_json_for_request()
+            ] = self.server_side_encryption.serialize_to_json_for_request()
         result['fileRetention'] = self._file_retention_dict(account_auth_token)
         result['legalHold'] = self._legal_hold_dict(account_auth_token)
         return result
@@ -355,14 +370,20 @@ class FileSimulator:
                 'value': None,
             }
 
-        file_lock_configuration = {'isClientAuthorizedToRead': True}
+        file_lock_configuration = {
+            'isClientAuthorizedToRead': True
+        }
         if self.file_retention is None:
-            file_lock_configuration['value'] = {'mode': None}
+            file_lock_configuration['value'] = {
+                'mode': None
+            }
         else:
-            file_lock_configuration['value'] = {'mode': self.file_retention.mode.value}
+            file_lock_configuration['value'] = {
+                'mode': self.file_retention.mode.value
+            }
             if self.file_retention.retain_until is not None:
                 file_lock_configuration['value']['retainUntilTimestamp'
-                                                ] = self.file_retention.retain_until
+                ] = self.file_retention.retain_until
         return file_lock_configuration
 
     def _legal_hold_dict(self, account_auth_token):
@@ -490,19 +511,19 @@ class BucketSimulator:
     MAX_SIMPLE_COPY_SIZE = 200  # should be same as RawSimulator.MIN_PART_SIZE
 
     def __init__(
-        self,
-        api,
-        account_id,
-        bucket_id,
-        bucket_name,
-        bucket_type,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        options_set=None,
-        default_server_side_encryption=None,
-        is_file_lock_enabled: Optional[bool] = None,
-        replication: Optional[ReplicationConfiguration] = None,
+            self,
+            api,
+            account_id,
+            bucket_id,
+            bucket_name,
+            bucket_type,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            options_set=None,
+            default_server_side_encryption=None,
+            is_file_lock_enabled: Optional[bool] = None,
+            replication: Optional[ReplicationConfiguration] = None,
     ):
         assert bucket_type in ['allPrivate', 'allPublic']
         self.api = api
@@ -551,15 +572,21 @@ class BucketSimulator:
         return capability in capabilities
 
     def bucket_dict(self, account_auth_token):
-        default_sse = {'isClientAuthorizedToRead': False}
+        default_sse = {
+            'isClientAuthorizedToRead': False
+        }
         if self.is_allowed_to_read_bucket_encryption_setting(account_auth_token):
             default_sse['isClientAuthorizedToRead'] = True
-            default_sse['value'] = {'mode': self.default_server_side_encryption.mode.value}
+            default_sse['value'] = {
+                'mode': self.default_server_side_encryption.mode.value
+            }
             if self.default_server_side_encryption.algorithm is not None:
                 default_sse['value']['algorithm'
-                                    ] = self.default_server_side_encryption.algorithm.value
+                ] = self.default_server_side_encryption.algorithm.value
         else:
-            default_sse['value'] = {'mode': EncryptionMode.UNKNOWN.value}
+            default_sse['value'] = {
+                'mode': EncryptionMode.UNKNOWN.value
+            }
 
         if self.is_allowed_to_read_bucket_retention(account_auth_token):
             file_lock_configuration = {
@@ -573,7 +600,10 @@ class BucketSimulator:
                 },
             }  # yapf: disable
         else:
-            file_lock_configuration = {'isClientAuthorizedToRead': False, 'value': None}
+            file_lock_configuration = {
+                'isClientAuthorizedToRead': False,
+                'value': None
+            }
 
         replication = self.replication and {
             'isClientAuthorizedToRead': True,
@@ -615,24 +645,24 @@ class BucketSimulator:
         return dict(fileId=file_id, fileName=file_name, uploadTimestamp=file_sim.upload_timestamp)
 
     def download_file_by_id(
-        self,
-        account_auth_token_or_none,
-        file_id,
-        url,
-        range_=None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            account_auth_token_or_none,
+            file_id,
+            url,
+            range_=None,
+            encryption: Optional[EncryptionSetting] = None,
     ):
         file_sim = self.file_id_to_file[file_id]
         file_sim.check_encryption(encryption)
         return self._download_file_sim(account_auth_token_or_none, file_sim, url, range_=range_)
 
     def download_file_by_name(
-        self,
-        account_auth_token_or_none,
-        file_name,
-        url,
-        range_=None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            account_auth_token_or_none,
+            file_name,
+            url,
+            range_=None,
+            encryption: Optional[EncryptionSetting] = None,
     ):
         files = self.list_file_names(self.api.current_token, file_name,
                                      1)['files']  # token is not important here
@@ -683,7 +713,7 @@ class BucketSimulator:
 
     def get_upload_part_url(self, account_auth_token, file_id):
         upload_url = 'https://upload.example.com/part/%s/%d/%s' % (
-            file_id, random.randint(1, 10**9), account_auth_token
+            file_id, random.randint(1, 10 ** 9), account_auth_token
         )
         return dict(bucketId=self.bucket_id, uploadUrl=upload_url, authorizationToken=upload_url)
 
@@ -698,12 +728,12 @@ class BucketSimulator:
         return file_sim.as_list_files_dict(account_auth_token)
 
     def update_file_retention(
-        self,
-        account_auth_token,
-        file_id,
-        file_name,
-        file_retention: FileRetentionSetting,
-        bypass_governance: bool = False,
+            self,
+            account_auth_token,
+            file_id,
+            file_name,
+            file_retention: FileRetentionSetting,
+            bypass_governance: bool = False,
     ):
         file_sim = self.file_id_to_file[file_id]
         assert self.is_file_lock_enabled
@@ -717,11 +747,11 @@ class BucketSimulator:
         }
 
     def update_file_legal_hold(
-        self,
-        account_auth_token,
-        file_id,
-        file_name,
-        legal_hold: LegalHold,
+            self,
+            account_auth_token,
+            file_id,
+            file_name,
+            legal_hold: LegalHold,
     ):
         file_sim = self.file_id_to_file[file_id]
         assert self.is_file_lock_enabled
@@ -734,24 +764,24 @@ class BucketSimulator:
         }
 
     def copy_file(
-        self,
-        account_auth_token,
-        file_id,
-        new_file_name,
-        bytes_range=None,
-        metadata_directive=None,
-        content_type=None,
-        file_info=None,
-        destination_bucket_id=None,
-        destination_server_side_encryption: Optional[EncryptionSetting] = None,
-        source_server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            account_auth_token,
+            file_id,
+            new_file_name,
+            bytes_range=None,
+            metadata_directive=None,
+            content_type=None,
+            file_info=None,
+            destination_bucket_id=None,
+            destination_server_side_encryption: Optional[EncryptionSetting] = None,
+            source_server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         if metadata_directive is not None:
             assert metadata_directive in tuple(MetadataDirectiveMode), metadata_directive
             if metadata_directive is MetadataDirectiveMode.COPY and (
-                content_type is not None or file_info is not None
+                    content_type is not None or file_info is not None
             ):
                 raise InvalidMetadataDirective(
                     'content_type and file_info should be None when metadata_directive is COPY'
@@ -798,14 +828,14 @@ class BucketSimulator:
             copy_file_sim.file_info = file_info or file_sim.file_info
 
         ## long term storage of that file has action="upload", but here we need to return action="copy", just this once
-        #class TestFileVersionFactory(FileVersionFactory):
+        # class TestFileVersionFactory(FileVersionFactory):
         #    FILE_VERSION_CLASS = self.FILE_SIMULATOR_CLASS
 
-        #file_version_dict = copy_file_sim.as_upload_result(account_auth_token)
-        #del file_version_dict['action']
-        #print(file_version_dict)
-        #copy_file_sim_with_action_copy = TestFileVersionFactory(self.api).from_api_response(file_version_dict, force_action='copy')
-        #return copy_file_sim_with_action_copy
+        # file_version_dict = copy_file_sim.as_upload_result(account_auth_token)
+        # del file_version_dict['action']
+        # print(file_version_dict)
+        # copy_file_sim_with_action_copy = TestFileVersionFactory(self.api).from_api_response(file_version_dict, force_action='copy')
+        # return copy_file_sim_with_action_copy
 
         # TODO: the code above cannot be used right now because FileSimulator.__init__ is incompatible with FileVersionFactory / FileVersion.__init__ - refactor is needed
         # for now we'll just return the newly constructed object with a copy action...
@@ -826,14 +856,14 @@ class BucketSimulator:
         )
 
     def list_file_names(
-        self,
-        account_auth_token,
-        start_file_name=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            account_auth_token,
+            start_file_name=None,
+            max_file_count=None,
+            prefix=None,
     ):
         assert prefix is None or start_file_name is None or start_file_name.startswith(prefix
-                                                                                      ), locals()
+                                                                                       ), locals()
         start_file_name = start_file_name or ''
         max_file_count = max_file_count or 100
         result_files = []
@@ -857,15 +887,15 @@ class BucketSimulator:
         return dict(files=result_files, nextFileName=next_file_name)
 
     def list_file_versions(
-        self,
-        account_auth_token,
-        start_file_name=None,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            account_auth_token,
+            start_file_name=None,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None,
     ):
         assert prefix is None or start_file_name is None or start_file_name.startswith(prefix
-                                                                                      ), locals()
+                                                                                       ), locals()
         start_file_name = start_file_name or ''
         start_file_id = start_file_id or ''
         max_file_count = max_file_count or 100
@@ -875,8 +905,8 @@ class BucketSimulator:
         for key in sorted(self.file_name_and_id_to_file):
             (file_name, file_id) = key
             if (start_file_name < file_name) or (
-                start_file_name == file_name and
-                (start_file_id == '' or int(start_file_id) <= int(file_id))
+                    start_file_name == file_name and
+                    (start_file_id == '' or int(start_file_id) <= int(file_id))
             ):
                 file_sim = self.file_name_and_id_to_file[key]
                 if prefix is not None and not file_name.startswith(prefix):
@@ -893,7 +923,7 @@ class BucketSimulator:
         return file_sim.list_parts(start_part_number, max_part_count)
 
     def list_unfinished_large_files(
-        self, account_auth_token, start_file_id=None, max_file_count=None, prefix=None
+            self, account_auth_token, start_file_id=None, max_file_count=None, prefix=None
     ):
         start_file_id = start_file_id or self.FIRST_FILE_ID
         max_file_count = max_file_count or 100
@@ -916,14 +946,14 @@ class BucketSimulator:
         return dict(files=file_dict_list, nextFileId=next_file_id)
 
     def start_large_file(
-        self,
-        account_auth_token,
-        file_name,
-        content_type,
-        file_info,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            account_auth_token,
+            file_name,
+            content_type,
+            file_info,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         file_id = self._next_file_id()
         sse = server_side_encryption or self.default_server_side_encryption
@@ -939,16 +969,16 @@ class BucketSimulator:
         return file_sim.as_start_large_file_result(account_auth_token)
 
     def _update_bucket(
-        self,
-        bucket_type=None,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        if_revision_is: Optional[int] = None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        default_retention: Optional[BucketRetentionSetting] = None,
-        replication: Optional[ReplicationConfiguration] = None,
-        is_file_lock_enabled: Optional[bool] = None,
+            self,
+            bucket_type=None,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            if_revision_is: Optional[int] = None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            default_retention: Optional[BucketRetentionSetting] = None,
+            replication: Optional[ReplicationConfiguration] = None,
+            is_file_lock_enabled: Optional[bool] = None,
     ):
         if if_revision_is is not None and self.revision != if_revision_is:
             raise Conflict()
@@ -958,8 +988,8 @@ class BucketSimulator:
                 raise DisablingFileLockNotSupported()
 
             if (
-                not self.is_file_lock_enabled and is_file_lock_enabled and self.replication and
-                self.replication.is_source
+                    not self.is_file_lock_enabled and is_file_lock_enabled and self.replication and
+                    self.replication.is_source
             ):
                 raise SourceReplicationConflict()
 
@@ -984,18 +1014,18 @@ class BucketSimulator:
         return self.bucket_dict(self.api.current_token)
 
     def upload_file(
-        self,
-        upload_id: str,
-        upload_auth_token: str,
-        file_name: str,
-        content_length: int,
-        content_type: str,
-        content_sha1: str,
-        file_infos: dict,
-        data_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            upload_id: str,
+            upload_auth_token: str,
+            file_name: str,
+            content_length: int,
+            content_type: str,
+            content_sha1: str,
+            file_infos: dict,
+            data_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         data_bytes = self._simulate_chunked_post(data_stream, content_length)
         assert len(data_bytes) == content_length
@@ -1036,13 +1066,13 @@ class BucketSimulator:
         return file_sim.as_upload_result(upload_auth_token)
 
     def upload_part(
-        self,
-        file_id,
-        part_number,
-        content_length,
-        sha1_sum,
-        input_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            file_id,
+            part_number,
+            content_length,
+            sha1_sum,
+            input_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         file_sim = self.file_id_to_file[file_id]
         part_data = self._simulate_chunked_post(input_stream, content_length)
@@ -1067,7 +1097,7 @@ class BucketSimulator:
         return result
 
     def _simulate_chunked_post(
-        self, stream, content_length, min_chunks=4, max_chunk_size=8096, simulate_retry=True
+            self, stream, content_length, min_chunks=4, max_chunk_size=8096, simulate_retry=True
     ):
         chunk_size = max_chunk_size
         chunks_num = self._chunks_number(content_length, chunk_size)
@@ -1239,18 +1269,18 @@ class RawSimulator(AbstractRawApi):
         return bucket.cancel_large_file(file_id)
 
     def create_bucket(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        bucket_name,
-        bucket_type,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        is_file_lock_enabled: Optional[bool] = None,
-        replication: Optional[ReplicationConfiguration] = None,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            bucket_name,
+            bucket_type,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            is_file_lock_enabled: Optional[bool] = None,
+            replication: Optional[ReplicationConfiguration] = None,
     ):
         if not re.match(r'^[-a-zA-Z0-9]*$', bucket_name):
             raise BadJson('illegal bucket name: ' + bucket_name)
@@ -1277,15 +1307,15 @@ class RawSimulator(AbstractRawApi):
         return bucket.bucket_dict(account_auth_token)  # TODO it should be an object, right?
 
     def create_key(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        capabilities,
-        key_name,
-        valid_duration_seconds,
-        bucket_id,
-        name_prefix,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            capabilities,
+            key_name,
+            valid_duration_seconds,
+            bucket_id,
+            name_prefix,
     ):
         if not re.match(r'^[A-Za-z0-9-]{1,100}$', key_name):
             raise BadJson('illegal key name: ' + key_name)
@@ -1331,13 +1361,13 @@ class RawSimulator(AbstractRawApi):
         return bucket.delete_file_version(file_id, file_name)
 
     def update_file_retention(
-        self,
-        api_url,
-        account_auth_token,
-        file_id,
-        file_name,
-        file_retention: FileRetentionSetting,
-        bypass_governance: bool = False,
+            self,
+            api_url,
+            account_auth_token,
+            file_id,
+            file_name,
+            file_retention: FileRetentionSetting,
+            bypass_governance: bool = False,
     ):
         bucket_id = self.file_id_to_bucket_id[file_id]
         bucket = self._get_bucket_by_id(bucket_id)
@@ -1350,12 +1380,12 @@ class RawSimulator(AbstractRawApi):
         )
 
     def update_file_legal_hold(
-        self,
-        api_url,
-        account_auth_token,
-        file_id,
-        file_name,
-        legal_hold: bool,
+            self,
+            api_url,
+            account_auth_token,
+            file_id,
+            file_name,
+            legal_hold: bool,
     ):
         bucket_id = self.file_id_to_bucket_id[file_id]
         bucket = self._get_bucket_by_id(bucket_id)
@@ -1374,11 +1404,11 @@ class RawSimulator(AbstractRawApi):
         return bucket.bucket_dict(account_auth_token)
 
     def download_file_from_url(
-        self,
-        account_auth_token_or_none,
-        url,
-        range_=None,
-        encryption: Optional[EncryptionSetting] = None
+            self,
+            account_auth_token_or_none,
+            url,
+            range_=None,
+            encryption: Optional[EncryptionSetting] = None
     ):
         # TODO: check auth token if bucket is not public
         matcher = self.DOWNLOAD_URL_MATCHER.match(url)
@@ -1429,7 +1459,7 @@ class RawSimulator(AbstractRawApi):
         return bucket.finish_large_file(account_auth_token, file_id, part_sha1_array)
 
     def get_download_authorization(
-        self, api_url, account_auth_token, bucket_id, file_name_prefix, valid_duration_in_seconds
+            self, api_url, account_auth_token, bucket_id, file_name_prefix, valid_duration_in_seconds
     ):
         bucket = self._get_bucket_by_id(bucket_id)
         self._assert_account_auth(api_url, account_auth_token, bucket.account_id, 'shareFiles')
@@ -1475,20 +1505,20 @@ class RawSimulator(AbstractRawApi):
         return response
 
     def copy_file(
-        self,
-        api_url,
-        account_auth_token,
-        source_file_id,
-        new_file_name,
-        bytes_range=None,
-        metadata_directive=None,
-        content_type=None,
-        file_info=None,
-        destination_bucket_id=None,
-        destination_server_side_encryption=None,
-        source_server_side_encryption=None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            api_url,
+            account_auth_token,
+            source_file_id,
+            new_file_name,
+            bytes_range=None,
+            metadata_directive=None,
+            content_type=None,
+            file_info=None,
+            destination_bucket_id=None,
+            destination_server_side_encryption=None,
+            source_server_side_encryption=None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         bucket_id = self.file_id_to_bucket_id[source_file_id]
         bucket = self._get_bucket_by_id(bucket_id)
@@ -1519,15 +1549,15 @@ class RawSimulator(AbstractRawApi):
         return copy_file_sim.as_upload_result(account_auth_token)
 
     def copy_part(
-        self,
-        api_url,
-        account_auth_token,
-        source_file_id,
-        large_file_id,
-        part_number,
-        bytes_range=None,
-        destination_server_side_encryption: Optional[EncryptionSetting] = None,
-        source_server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            api_url,
+            account_auth_token,
+            source_file_id,
+            large_file_id,
+            part_number,
+            bytes_range=None,
+            destination_server_side_encryption: Optional[EncryptionSetting] = None,
+            source_server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         if destination_server_side_encryption is not None and destination_server_side_encryption.mode == EncryptionMode.SSE_B2:
             raise ValueError(
@@ -1558,7 +1588,7 @@ class RawSimulator(AbstractRawApi):
         )
 
     def list_buckets(
-        self, api_url, account_auth_token, account_id, bucket_id=None, bucket_name=None
+            self, api_url, account_auth_token, account_id, bucket_id=None, bucket_name=None
     ):
         # First, map the bucket name to a bucket_id, so that we can check auth.
         if bucket_name is None:
@@ -1586,18 +1616,18 @@ class RawSimulator(AbstractRawApi):
 
     def _bucket_matches(self, bucket, bucket_id, bucket_name):
         return (
-            (bucket_id is None or bucket.bucket_id == bucket_id) and
-            (bucket_name is None or bucket.bucket_name == bucket_name)
+                (bucket_id is None or bucket.bucket_id == bucket_id) and
+                (bucket_name is None or bucket.bucket_name == bucket_name)
         )
 
     def list_file_names(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_name=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_name=None,
+            max_file_count=None,
+            prefix=None,
     ):
         bucket = self._get_bucket_by_id(bucket_id)
         self._assert_account_auth(
@@ -1611,14 +1641,14 @@ class RawSimulator(AbstractRawApi):
         return bucket.list_file_names(account_auth_token, start_file_name, max_file_count, prefix)
 
     def list_file_versions(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_name=None,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_name=None,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None,
     ):
         bucket = self._get_bucket_by_id(bucket_id)
         self._assert_account_auth(
@@ -1638,12 +1668,12 @@ class RawSimulator(AbstractRawApi):
         )
 
     def list_keys(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        max_key_count=1000,
-        start_application_key_id=None
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            max_key_count=1000,
+            start_application_key_id=None
     ):
         self._assert_account_auth(api_url, account_auth_token, account_id, 'listKeys')
         next_application_key_id = None
@@ -1674,13 +1704,13 @@ class RawSimulator(AbstractRawApi):
         return bucket.list_parts(file_id, start_part_number, max_part_count)
 
     def list_unfinished_large_files(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None
     ):
         bucket = self._get_bucket_by_id(bucket_id)
         self._assert_account_auth(
@@ -1693,16 +1723,16 @@ class RawSimulator(AbstractRawApi):
         )
 
     def start_large_file(
-        self,
-        api_url,
-        account_auth_token,
-        bucket_id,
-        file_name,
-        content_type,
-        file_info,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            api_url,
+            account_auth_token,
+            bucket_id,
+            file_name,
+            content_type,
+            file_info,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         bucket = self._get_bucket_by_id(bucket_id)
         self._assert_account_auth(api_url, account_auth_token, bucket.account_id, 'writeFiles')
@@ -1720,20 +1750,20 @@ class RawSimulator(AbstractRawApi):
         return result
 
     def update_bucket(
-        self,
-        api_url,
-        account_auth_token,
-        account_id,
-        bucket_id,
-        bucket_type=None,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        if_revision_is=None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        default_retention: Optional[BucketRetentionSetting] = None,
-        replication: Optional[ReplicationConfiguration] = None,
-        is_file_lock_enabled: Optional[bool] = None,
+            self,
+            api_url,
+            account_auth_token,
+            account_id,
+            bucket_id,
+            bucket_type=None,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            if_revision_is=None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            default_retention: Optional[BucketRetentionSetting] = None,
+            replication: Optional[ReplicationConfiguration] = None,
+            is_file_lock_enabled: Optional[bool] = None,
     ):
         assert bucket_type or bucket_info or cors_rules or lifecycle_rules or default_server_side_encryption or replication or is_file_lock_enabled is not None
         bucket = self._get_bucket_by_id(bucket_id)
@@ -1752,22 +1782,22 @@ class RawSimulator(AbstractRawApi):
 
     @classmethod
     def get_upload_file_headers(
-        cls,
-        upload_auth_token: str,
-        file_name: str,
-        content_length: int,
-        content_type: str,
-        content_sha1: str,
-        file_infos: dict,
-        server_side_encryption: Optional[EncryptionSetting],
-        file_retention: Optional[FileRetentionSetting],
-        legal_hold: Optional[LegalHold],
+            cls,
+            upload_auth_token: str,
+            file_name: str,
+            content_length: int,
+            content_type: str,
+            content_sha1: str,
+            file_infos: dict,
+            server_side_encryption: Optional[EncryptionSetting],
+            file_retention: Optional[FileRetentionSetting],
+            legal_hold: Optional[LegalHold],
     ) -> dict:
 
         # fix to allow calculating headers on unknown key - only for simulation
         if server_side_encryption is not None \
-           and server_side_encryption.mode == EncryptionMode.SSE_C \
-           and server_side_encryption.key.secret is None:
+                and server_side_encryption.mode == EncryptionMode.SSE_C \
+                and server_side_encryption.key.secret is None:
             server_side_encryption.key.secret = b'secret'
 
         return super().get_upload_file_headers(
@@ -1783,21 +1813,21 @@ class RawSimulator(AbstractRawApi):
         )
 
     def upload_file(
-        self,
-        upload_url: str,
-        upload_auth_token: str,
-        file_name: str,
-        content_length: int,
-        content_type: str,
-        content_sha1: str,
-        file_infos: dict,
-        data_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            upload_url: str,
+            upload_auth_token: str,
+            file_name: str,
+            content_length: int,
+            content_type: str,
+            content_sha1: str,
+            file_infos: dict,
+            data_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         with ConcurrentUsedAuthTokenGuard(
-            self.currently_used_auth_tokens[upload_auth_token], upload_auth_token
+                self.currently_used_auth_tokens[upload_auth_token], upload_auth_token
         ):
             assert upload_url == upload_auth_token
             url_match = self.UPLOAD_URL_MATCHER.match(upload_url)
@@ -1846,17 +1876,17 @@ class RawSimulator(AbstractRawApi):
         return response
 
     def upload_part(
-        self,
-        upload_url,
-        upload_auth_token,
-        part_number,
-        content_length,
-        sha1_sum,
-        input_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            upload_url,
+            upload_auth_token,
+            part_number,
+            content_length,
+            sha1_sum,
+            input_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         with ConcurrentUsedAuthTokenGuard(
-            self.currently_used_auth_tokens[upload_auth_token], upload_auth_token
+                self.currently_used_auth_tokens[upload_auth_token], upload_auth_token
         ):
             url_match = self.UPLOAD_PART_MATCHER.match(upload_url)
             if url_match is None:
@@ -1872,7 +1902,7 @@ class RawSimulator(AbstractRawApi):
         return part
 
     def _assert_account_auth(
-        self, api_url, account_auth_token, account_id, capability, bucket_id=None, file_name=None
+            self, api_url, account_auth_token, account_id, capability, bucket_id=None, file_name=None
     ):
         key_sim = self.auth_token_to_key.get(account_auth_token)
         assert key_sim is not None

--- a/b2sdk/replication/monitoring.py
+++ b/b2sdk/replication/monitoring.py
@@ -11,19 +11,39 @@
 import sys
 
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
+from dataclasses import (
+    dataclass,
+    field,
+)
 from queue import Queue
-from typing import ClassVar, Iterator, Optional, Tuple, Type
+from typing import (
+    ClassVar,
+    Iterator,
+    Optional,
+    Tuple,
+    Type,
+)
 
 from ..api import B2Api
 from ..bucket import Bucket
 from ..encryption.setting import EncryptionMode
-from ..file_lock import NO_RETENTION_FILE_SETTING, LegalHold
+from ..file_lock import (
+    NO_RETENTION_FILE_SETTING,
+    LegalHold,
+)
 from ..scan.folder import B2Folder
 from ..scan.path import B2Path
-from ..scan.policies import DEFAULT_SCAN_MANAGER, ScanPoliciesManager
+from ..scan.policies import (
+    DEFAULT_SCAN_MANAGER,
+    ScanPoliciesManager,
+)
 from ..scan.report import ProgressReport
-from ..scan.scan import AbstractScanReport, AbstractScanResult, CountAndSampleScanReport, zip_folders
+from ..scan.scan import (
+    AbstractScanReport,
+    AbstractScanResult,
+    CountAndSampleScanReport,
+    zip_folders,
+)
 from .setting import ReplicationRule
 from .types import ReplicationStatus
 
@@ -57,7 +77,7 @@ class ReplicationScanResult(AbstractScanResult):
 
     @classmethod
     def from_files(
-        cls, source_file: Optional[B2Path] = None, destination_file: Optional[B2Path] = None
+            cls, source_file: Optional[B2Path] = None, destination_file: Optional[B2Path] = None
     ) -> 'ReplicationScanResult':
         params = {}
 
@@ -203,8 +223,8 @@ class ReplicationMonitor:
 
             def fill_queue():
                 for path in self.source_folder.all_files(
-                    policies_manager=self.scan_policies_manager,
-                    reporter=self.report,
+                        policies_manager=self.scan_policies_manager,
+                        reporter=self.report,
                 ):
                     queue.put((path,), block=True)
                 queue.put(None, block=True)

--- a/b2sdk/replication/setting.py
+++ b/b2sdk/replication/setting.py
@@ -11,8 +11,16 @@
 import re
 
 from builtins import classmethod
-from dataclasses import dataclass, field
-from typing import ClassVar, Dict, List, Optional
+from dataclasses import (
+    dataclass,
+    field,
+)
+from typing import (
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+)
 
 
 @dataclass
@@ -33,7 +41,7 @@ class ReplicationRule:
 
     REPLICATION_RULE_REGEX: ClassVar = re.compile(r'^[a-zA-Z0-9_\-]{1,64}$')
     MIN_PRIORITY: ClassVar[int] = 1
-    MAX_PRIORITY: ClassVar[int] = 2**31 - 1
+    MAX_PRIORITY: ClassVar[int] = 2 ** 31 - 1
 
     def __post_init__(self):
         if not self.destination_bucket_id:
@@ -64,12 +72,12 @@ class ReplicationRule:
     def from_dict(cls, value_dict: dict) -> 'ReplicationRule':
         kwargs = {}
         for field_, protocolField in (
-            ('destination_bucket_id', 'destinationBucketId'),
-            ('name', 'replicationRuleName'),
-            ('file_name_prefix', 'fileNamePrefix'),
-            ('include_existing_files', 'includeExistingFiles'),
-            ('is_enabled', 'isEnabled'),
-            ('priority', 'priority'),
+                ('destination_bucket_id', 'destinationBucketId'),
+                ('name', 'replicationRuleName'),
+                ('file_name_prefix', 'fileNamePrefix'),
+                ('include_existing_files', 'includeExistingFiles'),
+                ('is_enabled', 'isEnabled'),
+                ('priority', 'priority'),
         ):
             value = value_dict.get(
                 protocolField
@@ -186,7 +194,7 @@ class ReplicationConfiguration:
             ],
             source_key_id=source_dict.get('sourceApplicationKeyId'),
             source_to_destination_key_mapping=destination_dict.get('sourceToDestinationKeyMapping')
-            or {},
+                                              or {},
         )
 
 

--- a/b2sdk/replication/setup.py
+++ b/b2sdk/replication/setup.py
@@ -18,7 +18,12 @@
 # b2 replication-deny destinationBucketName sourceKeyId
 
 from collections.abc import Iterable
-from typing import ClassVar, List, Optional, Tuple
+from typing import (
+    ClassVar,
+    List,
+    Optional,
+    Tuple,
+)
 import itertools
 import logging
 
@@ -26,7 +31,10 @@ from b2sdk.api import B2Api
 from b2sdk.application_key import ApplicationKey
 from b2sdk.bucket import Bucket
 from b2sdk.utils import B2TraceMeta
-from b2sdk.replication.setting import ReplicationConfiguration, ReplicationRule
+from b2sdk.replication.setting import (
+    ReplicationConfiguration,
+    ReplicationRule,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,13 +65,13 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
     )
 
     def setup_both(
-        self,
-        source_bucket: Bucket,
-        destination_bucket: Bucket,
-        name: Optional[str] = None,  #: name for the new replication rule
-        priority: int = None,  #: priority for the new replication rule
-        prefix: Optional[str] = None,
-        include_existing_files: bool = False,
+            self,
+            source_bucket: Bucket,
+            destination_bucket: Bucket,
+            name: Optional[str] = None,  #: name for the new replication rule
+            priority: int = None,  #: priority for the new replication rule
+            prefix: Optional[str] = None,
+            include_existing_files: bool = False,
     ) -> Tuple[Bucket, Bucket]:
 
         # setup source key
@@ -93,9 +101,9 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
         return new_source_bucket, new_destination_bucket
 
     def setup_destination(
-        self,
-        source_key_id: str,
-        destination_bucket: Bucket,
+            self,
+            source_key_id: str,
+            destination_bucket: Bucket,
     ) -> Bucket:
         api: B2Api = destination_bucket.api
 
@@ -104,7 +112,9 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
         ) if destination_bucket.replication else {}
 
         destination_configuration = destination_bucket.replication.get_destination_configuration_as_dict(
-        ) if destination_bucket.replication else {'source_to_destination_key_mapping': {}}
+        ) if destination_bucket.replication else {
+            'source_to_destination_key_mapping': {}
+        }
 
         keys_to_purge, destination_key = self._get_destination_key(
             api,
@@ -125,9 +135,9 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
 
     @classmethod
     def _get_destination_key(
-        cls,
-        api: B2Api,
-        destination_bucket: Bucket,
+            cls,
+            api: B2Api,
+            destination_bucket: Bucket,
     ):
         keys_to_purge = []
         if destination_bucket.replication is not None:
@@ -148,7 +158,7 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
                 keys_to_purge.append(current_destination_key_id)
                 continue
             if current_destination_key.has_capabilities(
-                cls.DEFAULT_DESTINATION_CAPABILITIES
+                    cls.DEFAULT_DESTINATION_CAPABILITIES
             ) and not current_destination_key.name_prefix:
                 logger.debug('matching destination key found: %s', current_destination_key_id)
                 key = current_destination_key
@@ -165,14 +175,14 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
         return keys_to_purge, key
 
     def setup_source(
-        self,
-        source_bucket: Bucket,
-        source_key: ApplicationKey,
-        destination_bucket: Bucket,
-        prefix: Optional[str] = None,
-        name: Optional[str] = None,  #: name for the new replication rule
-        priority: int = None,  #: priority for the new replication rule
-        include_existing_files: bool = False,
+            self,
+            source_bucket: Bucket,
+            source_key: ApplicationKey,
+            destination_bucket: Bucket,
+            prefix: Optional[str] = None,
+            name: Optional[str] = None,  #: name for the new replication rule
+            priority: int = None,  #: priority for the new replication rule
+            include_existing_files: bool = False,
     ) -> Bucket:
         if prefix is None:
             prefix = ""
@@ -213,10 +223,10 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
 
     @classmethod
     def _get_source_key(
-        cls,
-        source_bucket: Bucket,
-        prefix: str,
-        current_replication_configuration: ReplicationConfiguration,
+            cls,
+            source_bucket: Bucket,
+            prefix: str,
+            current_replication_configuration: ReplicationConfiguration,
     ) -> ApplicationKey:
         api = source_bucket.api
 
@@ -238,9 +248,9 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
 
     @classmethod
     def _should_make_new_source_key(
-        cls,
-        current_replication_configuration: ReplicationConfiguration,
-        current_source_key: Optional[ApplicationKey],
+            cls,
+            current_replication_configuration: ReplicationConfiguration,
+            current_source_key: Optional[ApplicationKey],
     ) -> bool:
         if current_replication_configuration.source_key_id is None:
             logger.debug('will create a new source key because no key is set')
@@ -271,10 +281,10 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
 
     @classmethod
     def _create_source_key(
-        cls,
-        name: str,
-        bucket: Bucket,
-        prefix: Optional[str] = None,
+            cls,
+            name: str,
+            bucket: Bucket,
+            prefix: Optional[str] = None,
     ) -> ApplicationKey:
         # in this implementation we ignore the prefix and create a full key, because
         # if someone would need a different (wider) key later, all replication
@@ -287,21 +297,21 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
 
     @classmethod
     def _create_destination_key(
-        cls,
-        name: str,
-        bucket: Bucket,
-        prefix: Optional[str] = None,
+            cls,
+            name: str,
+            bucket: Bucket,
+            prefix: Optional[str] = None,
     ) -> ApplicationKey:
         capabilities = cls.DEFAULT_DESTINATION_CAPABILITIES
         return cls._create_key(name, bucket, prefix, capabilities)
 
     @classmethod
     def _create_key(
-        cls,
-        name: str,
-        bucket: Bucket,
-        prefix: Optional[str] = None,
-        capabilities=tuple(),
+            cls,
+            name: str,
+            bucket: Bucket,
+            prefix: Optional[str] = None,
+            capabilities=tuple(),
     ) -> ApplicationKey:
         api: B2Api = bucket.api
         return api.create_key(
@@ -313,9 +323,9 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
 
     @classmethod
     def _get_priority_for_new_rule(
-        cls,
-        current_rules: Iterable[ReplicationRule],
-        priority: Optional[int] = None,
+            cls,
+            current_rules: Iterable[ReplicationRule],
+            priority: Optional[int] = None,
     ):
         if priority is not None:
             return priority
@@ -327,10 +337,10 @@ class ReplicationSetupHelper(metaclass=B2TraceMeta):
 
     @classmethod
     def _get_new_rule_name(
-        cls,
-        current_rules: Iterable[ReplicationRule],
-        destination_bucket: Bucket,
-        name: Optional[str] = None,
+            cls,
+            current_rules: Iterable[ReplicationRule],
+            destination_bucket: Bucket,
+            name: Optional[str] = None,
     ):
         if name is not None:
             return name

--- a/b2sdk/replication/types.py
+++ b/b2sdk/replication/types.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from enum import Enum, unique
+from enum import (
+    Enum,
+    unique,
+)
 from typing import Optional
 
 

--- a/b2sdk/requests/__init__.py
+++ b/b2sdk/requests/__init__.py
@@ -15,10 +15,24 @@ Copyright 2019 Kenneth Reitz
 Changes made to the original source: see NOTICE
 """
 
-from requests import Response, ConnectionError
-from requests.exceptions import ChunkedEncodingError, ContentDecodingError, StreamConsumedError
-from requests.utils import iter_slices, stream_decode_response_unicode
-from urllib3.exceptions import ProtocolError, DecodeError, ReadTimeoutError
+from requests import (
+    Response,
+    ConnectionError,
+)
+from requests.exceptions import (
+    ChunkedEncodingError,
+    ContentDecodingError,
+    StreamConsumedError,
+)
+from requests.utils import (
+    iter_slices,
+    stream_decode_response_unicode,
+)
+from urllib3.exceptions import (
+    ProtocolError,
+    DecodeError,
+    ReadTimeoutError,
+)
 
 from . import included_source_meta
 

--- a/b2sdk/requests/included_source_meta.py
+++ b/b2sdk/requests/included_source_meta.py
@@ -7,7 +7,10 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
-from b2sdk.included_sources import add_included_source, IncludedSourceMeta
+from b2sdk.included_sources import (
+    add_included_source,
+    IncludedSourceMeta,
+)
 
 included_source_meta = IncludedSourceMeta(
     'requests', 'Included in a revised form', {

--- a/b2sdk/scan/exception.py
+++ b/b2sdk/scan/exception.py
@@ -9,9 +9,15 @@
 ######################################################################
 
 from contextlib import contextmanager
-from typing import Iterator, Type
+from typing import (
+    Iterator,
+    Type,
+)
 
-from ..exception import B2Error, B2SimpleError
+from ..exception import (
+    B2Error,
+    B2SimpleError,
+)
 
 
 class EnvironmentEncodingError(B2Error):

--- a/b2sdk/scan/folder.py
+++ b/b2sdk/scan/folder.py
@@ -14,28 +14,48 @@ import platform
 import re
 import sys
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from typing import Iterator
 
-from ..utils import fix_windows_path_limit, get_file_mtime, is_file_readable
-from .exception import EmptyDirectory, EnvironmentEncodingError, NotADirectory, UnableToCreateDirectory, UnsupportedFilename
-from .path import AbstractPath, B2Path, LocalPath
-from .policies import DEFAULT_SCAN_MANAGER, ScanPoliciesManager
+from ..utils import (
+    fix_windows_path_limit,
+    get_file_mtime,
+    is_file_readable,
+)
+from .exception import (
+    EmptyDirectory,
+    EnvironmentEncodingError,
+    NotADirectory,
+    UnableToCreateDirectory,
+    UnsupportedFilename,
+)
+from .path import (
+    AbstractPath,
+    B2Path,
+    LocalPath,
+)
+from .policies import (
+    DEFAULT_SCAN_MANAGER,
+    ScanPoliciesManager,
+)
 from .report import ProgressReport
 
 DRIVE_MATCHER = re.compile(r"^([A-Za-z]):([/\\])")
 ABSOLUTE_PATH_MATCHER = re.compile(r"^(/)|^(\\)")
 RELATIVE_PATH_MATCHER = re.compile(
-                           # "abc" and "xyz" represent anything, including "nothing"
-    r"^(\.\.[/\\])|" +     # ../abc or ..\abc
-    r"^(\.[/\\])|" +       # ./abc or .\abc
-    r"([/\\]\.\.[/\\])|" + # abc/../xyz or abc\..\xyz or abc\../xyz or abc/..\xyz
-    r"([/\\]\.[/\\])|" +   # abc/./xyz or abc\.\xyz or abc\./xyz or abc/.\xyz
-    r"([/\\]\.\.)$|" +     # abc/.. or abc\..
-    r"([/\\]\.)$|" +       # abc/. or abc\.
-    r"^(\.\.)$|" +         # just ".."
-    r"([/\\][/\\])|" +     # abc\/xyz or abc/\xyz or abc//xyz or abc\\xyz
-    r"^(\.)$"              # just "."
+    # "abc" and "xyz" represent anything, including "nothing"
+    r"^(\.\.[/\\])|" +  # ../abc or ..\abc
+    r"^(\.[/\\])|" +  # ./abc or .\abc
+    r"([/\\]\.\.[/\\])|" +  # abc/../xyz or abc\..\xyz or abc\../xyz or abc/..\xyz
+    r"([/\\]\.[/\\])|" +  # abc/./xyz or abc\.\xyz or abc\./xyz or abc/.\xyz
+    r"([/\\]\.\.)$|" +  # abc/.. or abc\..
+    r"([/\\]\.)$|" +  # abc/. or abc\.
+    r"^(\.\.)$|" +  # just ".."
+    r"([/\\][/\\])|" +  # abc\/xyz or abc/\xyz or abc//xyz or abc\\xyz
+    r"^(\.)$"  # just "."
 )  # yapf: disable
 
 logger = logging.getLogger(__name__)
@@ -178,8 +198,8 @@ class LocalFolder(AbstractFolder):
             raise EmptyDirectory(self.root)
 
     def _walk_relative_paths(
-        self, local_dir: str, relative_dir_path: str, reporter,
-        policies_manager: ScanPoliciesManager
+            self, local_dir: str, relative_dir_path: str, reporter,
+            policies_manager: ScanPoliciesManager
     ):
         """
         Yield a File object for each of the files anywhere under this folder, in the
@@ -245,7 +265,7 @@ class LocalFolder(AbstractFolder):
         for (name, local_path, relative_file_path) in sorted(names):
             if name.endswith('/'):
                 for subdir_file in self._walk_relative_paths(
-                    local_path, relative_file_path, reporter, policies_manager
+                        local_path, relative_file_path, reporter, policies_manager
                 ):
                     yield subdir_file
             else:
@@ -318,9 +338,9 @@ class B2Folder(AbstractFolder):
             self.prefix += '/'
 
     def all_files(
-        self,
-        reporter: ProgressReport,
-        policies_manager: ScanPoliciesManager = DEFAULT_SCAN_MANAGER
+            self,
+            reporter: ProgressReport,
+            policies_manager: ScanPoliciesManager = DEFAULT_SCAN_MANAGER
     ) -> Iterator[B2Path]:
         """
         Yield all files.
@@ -373,9 +393,9 @@ class B2Folder(AbstractFolder):
 
     def get_file_versions(self):
         for file_version, _ in self.bucket.ls(
-            self.folder_name,
-            latest_only=False,
-            recursive=True,
+                self.folder_name,
+                latest_only=False,
+                recursive=True,
         ):
             yield file_version
 

--- a/b2sdk/scan/folder_parser.py
+++ b/b2sdk/scan/folder_parser.py
@@ -9,7 +9,10 @@
 ######################################################################
 
 from .exception import InvalidArgument
-from .folder import B2Folder, LocalFolder
+from .folder import (
+    B2Folder,
+    LocalFolder,
+)
 
 
 def parse_folder(folder_name, api, local_folder_class=LocalFolder, b2_folder_class=B2Folder):

--- a/b2sdk/scan/path.py
+++ b/b2sdk/scan/path.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from abc import ABC, abstractmethod
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from typing import List
 
 from ..file_version import FileVersion
@@ -46,9 +49,9 @@ class LocalPath(AbstractPath):
 
     def __eq__(self, other):
         return (
-            self.absolute_path == other.absolute_path and
-            self.relative_path == other.relative_path and self.mod_time == other.mod_time and
-            self.size == other.size
+                self.absolute_path == other.absolute_path and
+                self.relative_path == other.relative_path and self.mod_time == other.mod_time and
+                self.size == other.size
         )
 
 
@@ -56,7 +59,7 @@ class B2Path(AbstractPath):
     __slots__ = ['relative_path', 'selected_version', 'all_versions']
 
     def __init__(
-        self, relative_path: str, selected_version: FileVersion, all_versions: List[FileVersion]
+            self, relative_path: str, selected_version: FileVersion, all_versions: List[FileVersion]
     ):
         self.selected_version = selected_version
         self.all_versions = all_versions
@@ -86,7 +89,7 @@ class B2Path(AbstractPath):
 
     def __eq__(self, other):
         return (
-            self.relative_path == other.relative_path and
-            self.selected_version == other.selected_version and
-            self.all_versions == other.all_versions
+                self.relative_path == other.relative_path and
+                self.selected_version == other.selected_version and
+                self.all_versions == other.all_versions
         )

--- a/b2sdk/scan/policies.py
+++ b/b2sdk/scan/policies.py
@@ -11,10 +11,17 @@
 import logging
 import re
 
-from typing import Iterable, Optional, Union
+from typing import (
+    Iterable,
+    Optional,
+    Union,
+)
 
 from ..file_version import FileVersion
-from .exception import InvalidArgument, check_invalid_argument
+from .exception import (
+    InvalidArgument,
+    check_invalid_argument,
+)
 from .path import LocalPath
 
 logger = logging.getLogger(__name__)
@@ -121,15 +128,15 @@ class ScanPoliciesManager:
     """
 
     def __init__(
-        self,
-        exclude_dir_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
-        exclude_file_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
-        include_file_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
-        exclude_all_symlinks: bool = False,
-        exclude_modified_before: Optional[int] = None,
-        exclude_modified_after: Optional[int] = None,
-        exclude_uploaded_before: Optional[int] = None,
-        exclude_uploaded_after: Optional[int] = None,
+            self,
+            exclude_dir_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
+            exclude_file_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
+            include_file_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
+            exclude_all_symlinks: bool = False,
+            exclude_modified_before: Optional[int] = None,
+            exclude_modified_after: Optional[int] = None,
+            exclude_uploaded_before: Optional[int] = None,
+            exclude_uploaded_after: Optional[int] = None,
     ):
         """
         :param exclude_dir_regexes: regexes to exclude directories
@@ -154,29 +161,29 @@ class ScanPoliciesManager:
             )
 
         with check_invalid_argument(
-            'exclude_dir_regexes', 'wrong regex was given for excluding directories', re.error
+                'exclude_dir_regexes', 'wrong regex was given for excluding directories', re.error
         ):
             self._exclude_dir_set = RegexSet(exclude_dir_regexes)
             self._exclude_file_because_of_dir_set = RegexSet(
                 map(convert_dir_regex_to_dir_prefix_regex, exclude_dir_regexes)
             )
         with check_invalid_argument(
-            'exclude_file_regexes', 'wrong regex was given for excluding files', re.error
+                'exclude_file_regexes', 'wrong regex was given for excluding files', re.error
         ):
             self._exclude_file_set = RegexSet(exclude_file_regexes)
         with check_invalid_argument(
-            'include_file_regexes', 'wrong regex was given for including files', re.error
+                'include_file_regexes', 'wrong regex was given for including files', re.error
         ):
             self._include_file_set = RegexSet(include_file_regexes)
         self.exclude_all_symlinks = exclude_all_symlinks
         with check_invalid_argument(
-            'exclude_modified_before,exclude_modified_after', '', ValueError
+                'exclude_modified_before,exclude_modified_after', '', ValueError
         ):
             self._include_mod_time_range = IntegerRange(
                 exclude_modified_before, exclude_modified_after
             )
         with check_invalid_argument(
-            'exclude_uploaded_before,exclude_uploaded_after', '', ValueError
+                'exclude_uploaded_before,exclude_uploaded_after', '', ValueError
         ):
             self._include_upload_time_range = IntegerRange(
                 exclude_uploaded_before, exclude_uploaded_after

--- a/b2sdk/scan/scan.py
+++ b/b2sdk/scan/scan.py
@@ -8,23 +8,39 @@
 #
 ######################################################################
 
-from abc import ABCMeta, abstractclassmethod, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractclassmethod,
+    abstractmethod,
+)
 from collections import Counter
-from dataclasses import dataclass, field
-from typing import ClassVar, Dict, Optional, Tuple, Type
+from dataclasses import (
+    dataclass,
+    field,
+)
+from typing import (
+    ClassVar,
+    Dict,
+    Optional,
+    Tuple,
+    Type,
+)
 
 from ..file_version import FileVersion
 from .folder import AbstractFolder
 from .path import AbstractPath
-from .policies import DEFAULT_SCAN_MANAGER, ScanPoliciesManager
+from .policies import (
+    DEFAULT_SCAN_MANAGER,
+    ScanPoliciesManager,
+)
 from .report import ProgressReport
 
 
 def zip_folders(
-    folder_a: AbstractFolder,
-    folder_b: AbstractFolder,
-    reporter: ProgressReport,
-    policies_manager: ScanPoliciesManager = DEFAULT_SCAN_MANAGER,
+        folder_a: AbstractFolder,
+        folder_b: AbstractFolder,
+        reporter: ProgressReport,
+        policies_manager: ScanPoliciesManager = DEFAULT_SCAN_MANAGER,
 ) -> Tuple[Optional[AbstractPath], Optional[AbstractPath]]:
     """
     Iterate over all of the files in the union of two folders,

--- a/b2sdk/session.py
+++ b/b2sdk/session.py
@@ -9,21 +9,45 @@
 ######################################################################
 
 from functools import partial
-from enum import Enum, unique
-from typing import Any, Dict, Optional
+from enum import (
+    Enum,
+    unique,
+)
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
 import logging
 
 from b2sdk.account_info.abstract import AbstractAccountInfo
 from b2sdk.account_info.sqlite_account_info import SqliteAccountInfo
 from b2sdk.account_info.exception import MissingAccountData
 from b2sdk.b2http import B2Http
-from b2sdk.cache import AbstractCache, AuthInfoCache, DummyCache
+from b2sdk.cache import (
+    AbstractCache,
+    AuthInfoCache,
+    DummyCache,
+)
 from b2sdk.encryption.setting import EncryptionSetting
 from b2sdk.replication.setting import ReplicationConfiguration
-from b2sdk.exception import (InvalidAuthToken, Unauthorized)
-from b2sdk.file_lock import BucketRetentionSetting, FileRetentionSetting, LegalHold
-from b2sdk.raw_api import ALL_CAPABILITIES, REALM_URLS
-from b2sdk.api_config import B2HttpApiConfig, DEFAULT_HTTP_API_CONFIG
+from b2sdk.exception import (
+    InvalidAuthToken,
+    Unauthorized,
+)
+from b2sdk.file_lock import (
+    BucketRetentionSetting,
+    FileRetentionSetting,
+    LegalHold,
+)
+from b2sdk.raw_api import (
+    ALL_CAPABILITIES,
+    REALM_URLS,
+)
+from b2sdk.api_config import (
+    B2HttpApiConfig,
+    DEFAULT_HTTP_API_CONFIG,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,10 +69,10 @@ class B2Session:
     B2HTTP_CLASS = staticmethod(B2Http)
 
     def __init__(
-        self,
-        account_info: Optional[AbstractAccountInfo] = None,
-        cache: Optional[AbstractCache] = None,
-        api_config: B2HttpApiConfig = DEFAULT_HTTP_API_CONFIG
+            self,
+            account_info: Optional[AbstractAccountInfo] = None,
+            cache: Optional[AbstractCache] = None,
+            api_config: B2HttpApiConfig = DEFAULT_HTTP_API_CONFIG
     ):
         """
         Initialize Session using given account info.
@@ -138,16 +162,16 @@ class B2Session:
         return self._wrap_default_token(self.raw_api.cancel_large_file, file_id)
 
     def create_bucket(
-        self,
-        account_id,
-        bucket_name,
-        bucket_type,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        default_server_side_encryption=None,
-        is_file_lock_enabled: Optional[bool] = None,
-        replication: Optional[ReplicationConfiguration] = None,
+            self,
+            account_id,
+            bucket_name,
+            bucket_type,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            default_server_side_encryption=None,
+            is_file_lock_enabled: Optional[bool] = None,
+            replication: Optional[ReplicationConfiguration] = None,
     ):
         return self._wrap_default_token(
             self.raw_api.create_bucket,
@@ -163,7 +187,7 @@ class B2Session:
         )
 
     def create_key(
-        self, account_id, capabilities, key_name, valid_duration_seconds, bucket_id, name_prefix
+            self, account_id, capabilities, key_name, valid_duration_seconds, bucket_id, name_prefix
     ):
         return self._wrap_default_token(
             self.raw_api.create_key,
@@ -185,7 +209,7 @@ class B2Session:
         return self._wrap_default_token(self.raw_api.delete_file_version, file_id, file_name)
 
     def download_file_from_url(
-        self, url, range_=None, encryption: Optional[EncryptionSetting] = None
+            self, url, range_=None, encryption: Optional[EncryptionSetting] = None
     ):
         return self._wrap_token(
             self.raw_api.download_file_from_url,
@@ -228,11 +252,11 @@ class B2Session:
         )
 
     def list_file_names(
-        self,
-        bucket_id,
-        start_file_name=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            bucket_id,
+            start_file_name=None,
+            max_file_count=None,
+            prefix=None,
     ):
         return self._wrap_default_token(
             self.raw_api.list_file_names,
@@ -243,12 +267,12 @@ class B2Session:
         )
 
     def list_file_versions(
-        self,
-        bucket_id,
-        start_file_name=None,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            bucket_id,
+            start_file_name=None,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None,
     ):
         return self._wrap_default_token(
             self.raw_api.list_file_versions,
@@ -273,11 +297,11 @@ class B2Session:
         )
 
     def list_unfinished_large_files(
-        self,
-        bucket_id,
-        start_file_id=None,
-        max_file_count=None,
-        prefix=None,
+            self,
+            bucket_id,
+            start_file_id=None,
+            max_file_count=None,
+            prefix=None,
     ):
         return self._wrap_default_token(
             self.raw_api.list_unfinished_large_files,
@@ -288,14 +312,14 @@ class B2Session:
         )
 
     def start_large_file(
-        self,
-        bucket_id,
-        file_name,
-        content_type,
-        file_info,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            bucket_id,
+            file_name,
+            content_type,
+            file_info,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         return self._wrap_default_token(
             self.raw_api.start_large_file,
@@ -309,18 +333,18 @@ class B2Session:
         )
 
     def update_bucket(
-        self,
-        account_id,
-        bucket_id,
-        bucket_type=None,
-        bucket_info=None,
-        cors_rules=None,
-        lifecycle_rules=None,
-        if_revision_is=None,
-        default_server_side_encryption: Optional[EncryptionSetting] = None,
-        default_retention: Optional[BucketRetentionSetting] = None,
-        replication: Optional[ReplicationConfiguration] = None,
-        is_file_lock_enabled: Optional[bool] = None,
+            self,
+            account_id,
+            bucket_id,
+            bucket_type=None,
+            bucket_info=None,
+            cors_rules=None,
+            lifecycle_rules=None,
+            if_revision_is=None,
+            default_server_side_encryption: Optional[EncryptionSetting] = None,
+            default_retention: Optional[BucketRetentionSetting] = None,
+            replication: Optional[ReplicationConfiguration] = None,
+            is_file_lock_enabled: Optional[bool] = None,
     ):
         return self._wrap_default_token(
             self.raw_api.update_bucket,
@@ -338,17 +362,17 @@ class B2Session:
         )
 
     def upload_file(
-        self,
-        bucket_id,
-        file_name,
-        content_length,
-        content_type,
-        content_sha1,
-        file_infos,
-        data_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            bucket_id,
+            file_name,
+            content_length,
+            content_type,
+            content_sha1,
+            file_infos,
+            data_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         return self._wrap_token(
             self.raw_api.upload_file,
@@ -366,13 +390,13 @@ class B2Session:
         )
 
     def upload_part(
-        self,
-        file_id,
-        part_number,
-        content_length,
-        sha1_sum,
-        input_stream,
-        server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            file_id,
+            part_number,
+            content_length,
+            sha1_sum,
+            input_stream,
+            server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         return self._wrap_token(
             self.raw_api.upload_part,
@@ -394,18 +418,18 @@ class B2Session:
         )
 
     def copy_file(
-        self,
-        source_file_id,
-        new_file_name,
-        bytes_range=None,
-        metadata_directive=None,
-        content_type=None,
-        file_info=None,
-        destination_bucket_id=None,
-        destination_server_side_encryption: Optional[EncryptionSetting] = None,
-        source_server_side_encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            source_file_id,
+            new_file_name,
+            bytes_range=None,
+            metadata_directive=None,
+            content_type=None,
+            file_info=None,
+            destination_bucket_id=None,
+            destination_server_side_encryption: Optional[EncryptionSetting] = None,
+            source_server_side_encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         return self._wrap_default_token(
             self.raw_api.copy_file,
@@ -423,13 +447,13 @@ class B2Session:
         )
 
     def copy_part(
-        self,
-        source_file_id,
-        large_file_id,
-        part_number,
-        bytes_range=None,
-        destination_server_side_encryption: Optional[EncryptionSetting] = None,
-        source_server_side_encryption: Optional[EncryptionSetting] = None,
+            self,
+            source_file_id,
+            large_file_id,
+            part_number,
+            bytes_range=None,
+            destination_server_side_encryption: Optional[EncryptionSetting] = None,
+            source_server_side_encryption: Optional[EncryptionSetting] = None,
     ):
         return self._wrap_default_token(
             self.raw_api.copy_part,
@@ -543,11 +567,11 @@ class B2Session:
         return response
 
     def update_file_retention(
-        self,
-        file_id,
-        file_name,
-        file_retention: FileRetentionSetting,
-        bypass_governance: bool = False,
+            self,
+            file_id,
+            file_name,
+            file_retention: FileRetentionSetting,
+            bypass_governance: bool = False,
     ):
         return self._wrap_default_token(
             self.raw_api.update_file_retention,
@@ -558,10 +582,10 @@ class B2Session:
         )
 
     def update_file_legal_hold(
-        self,
-        file_id,
-        file_name,
-        legal_hold: LegalHold,
+            self,
+            file_id,
+            file_name,
+            legal_hold: LegalHold,
     ):
         return self._wrap_default_token(
             self.raw_api.update_file_legal_hold,

--- a/b2sdk/stream/__init__.py
+++ b/b2sdk/stream/__init__.py
@@ -9,7 +9,10 @@
 ######################################################################
 
 from .hashing import StreamWithHash
-from .progress import ReadingStreamWithProgress, WritingStreamWithProgress
+from .progress import (
+    ReadingStreamWithProgress,
+    WritingStreamWithProgress,
+)
 from .range import RangeOfInputStream
 
 __all__ = [

--- a/b2sdk/stream/chained.py
+++ b/b2sdk/stream/chained.py
@@ -10,7 +10,10 @@
 
 import io
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 
 from b2sdk.stream.base import ReadOnlyStreamMixin
 

--- a/b2sdk/sync/action.py
+++ b/b2sdk/sync/action.py
@@ -10,7 +10,10 @@
 
 import logging
 import os
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 
 from ..bucket import Bucket
 from ..http_constants import SRC_LAST_MODIFIED_MILLIS
@@ -87,13 +90,13 @@ class B2UploadAction(AbstractAction):
     """
 
     def __init__(
-        self,
-        local_full_path,
-        relative_name,
-        b2_file_name,
-        mod_time_millis,
-        size,
-        encryption_settings_provider: AbstractSyncEncryptionSettingsProvider,
+            self,
+            local_full_path,
+            relative_name,
+            b2_file_name,
+            mod_time_millis,
+            size,
+            encryption_settings_provider: AbstractSyncEncryptionSettingsProvider,
     ):
         """
         :param str local_full_path: a local file path
@@ -129,7 +132,9 @@ class B2UploadAction(AbstractAction):
             progress_listener = SyncFileReporter(reporter)
         else:
             progress_listener = None
-        file_info = {SRC_LAST_MODIFIED_MILLIS: str(self.mod_time_millis)}
+        file_info = {
+            SRC_LAST_MODIFIED_MILLIS: str(self.mod_time_millis)
+        }
         encryption = self.encryption_settings_provider.get_setting_for_upload(
             bucket=bucket,
             b2_file_name=self.b2_file_name,
@@ -207,11 +212,11 @@ class B2HideAction(AbstractAction):
 
 class B2DownloadAction(AbstractAction):
     def __init__(
-        self,
-        source_path: B2Path,
-        b2_file_name: str,
-        local_full_path: str,
-        encryption_settings_provider: AbstractSyncEncryptionSettingsProvider,
+            self,
+            source_path: B2Path,
+            b2_file_name: str,
+            local_full_path: str,
+            encryption_settings_provider: AbstractSyncEncryptionSettingsProvider,
     ):
         """
         :param b2sdk.v2.B2Path source_path: the file to be downloaded
@@ -290,10 +295,10 @@ class B2DownloadAction(AbstractAction):
 
     def __str__(self):
         return (
-            'b2_download(%s, %s, %s, %d)' % (
-                self.b2_file_name, self.source_path.selected_version.id_, self.local_full_path,
-                self.source_path.mod_time
-            )
+                'b2_download(%s, %s, %s, %d)' % (
+            self.b2_file_name, self.source_path.selected_version.id_, self.local_full_path,
+            self.source_path.mod_time
+        )
         )
 
 
@@ -303,13 +308,13 @@ class B2CopyAction(AbstractAction):
     """
 
     def __init__(
-        self,
-        b2_file_name: str,
-        source_path: B2Path,
-        dest_b2_file_name,
-        source_bucket: Bucket,
-        destination_bucket: Bucket,
-        encryption_settings_provider: AbstractSyncEncryptionSettingsProvider,
+            self,
+            b2_file_name: str,
+            source_path: B2Path,
+            dest_b2_file_name,
+            source_bucket: Bucket,
+            destination_bucket: Bucket,
+            encryption_settings_provider: AbstractSyncEncryptionSettingsProvider,
     ):
         """
         :param str b2_file_name: a b2_file_name
@@ -381,10 +386,10 @@ class B2CopyAction(AbstractAction):
 
     def __str__(self):
         return (
-            'b2_copy(%s, %s, %s, %d)' % (
-                self.b2_file_name, self.source_path.selected_version.id_, self.dest_b2_file_name,
-                self.source_path.mod_time
-            )
+                'b2_copy(%s, %s, %s, %d)' % (
+            self.b2_file_name, self.source_path.selected_version.id_, self.dest_b2_file_name,
+            self.source_path.mod_time
+        )
         )
 
 

--- a/b2sdk/sync/encryption_provider.py
+++ b/b2sdk/sync/encryption_provider.py
@@ -8,8 +8,14 @@
 #
 ######################################################################
 
-from abc import ABCMeta, abstractmethod
-from typing import Dict, Optional
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
+from typing import (
+    Dict,
+    Optional,
+)
 
 from ..encryption.setting import EncryptionSetting
 from ..bucket import Bucket
@@ -24,11 +30,11 @@ class AbstractSyncEncryptionSettingsProvider(metaclass=ABCMeta):
 
     @abstractmethod
     def get_setting_for_upload(
-        self,
-        bucket: Bucket,
-        b2_file_name: str,
-        file_info: Optional[dict],
-        length: int,
+            self,
+            bucket: Bucket,
+            b2_file_name: str,
+            file_info: Optional[dict],
+            length: int,
     ) -> Optional[EncryptionSetting]:
         """
         Return an EncryptionSetting for uploading an object or None if server should decide.
@@ -36,9 +42,9 @@ class AbstractSyncEncryptionSettingsProvider(metaclass=ABCMeta):
 
     @abstractmethod
     def get_source_setting_for_copy(
-        self,
-        bucket: Bucket,
-        source_file_version: FileVersion,
+            self,
+            bucket: Bucket,
+            source_file_version: FileVersion,
     ) -> Optional[EncryptionSetting]:
         """
         Return an EncryptionSetting for a source of copying an object or None if not required
@@ -46,11 +52,11 @@ class AbstractSyncEncryptionSettingsProvider(metaclass=ABCMeta):
 
     @abstractmethod
     def get_destination_setting_for_copy(
-        self,
-        bucket: Bucket,
-        dest_b2_file_name: str,
-        source_file_version: FileVersion,
-        target_file_info: Optional[dict] = None,
+            self,
+            bucket: Bucket,
+            dest_b2_file_name: str,
+            source_file_version: FileVersion,
+            target_file_info: Optional[dict] = None,
     ) -> Optional[EncryptionSetting]:
         """
         Return an EncryptionSetting for a destination for copying an object or None if server should decide
@@ -58,9 +64,9 @@ class AbstractSyncEncryptionSettingsProvider(metaclass=ABCMeta):
 
     @abstractmethod
     def get_setting_for_download(
-        self,
-        bucket: Bucket,
-        file_version: FileVersion,
+            self,
+            bucket: Bucket,
+            file_version: FileVersion,
     ) -> Optional[EncryptionSetting]:
         """
         Return an EncryptionSetting for downloading an object from, or None if not required
@@ -96,9 +102,9 @@ class BasicSyncEncryptionSettingsProvider(AbstractSyncEncryptionSettingsProvider
     """
 
     def __init__(
-        self,
-        read_bucket_settings: Dict[str, Optional[EncryptionSetting]],
-        write_bucket_settings: Dict[str, Optional[EncryptionSetting]],
+            self,
+            read_bucket_settings: Dict[str, Optional[EncryptionSetting]],
+            write_bucket_settings: Dict[str, Optional[EncryptionSetting]],
     ):
         self.read_bucket_settings = read_bucket_settings
         self.write_bucket_settings = write_bucket_settings

--- a/b2sdk/sync/policy.py
+++ b/b2sdk/sync/policy.py
@@ -10,16 +10,32 @@
 
 import logging
 
-from abc import ABCMeta, abstractmethod
-from enum import Enum, unique
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
+from enum import (
+    Enum,
+    unique,
+)
 from typing import Optional
 
 from ..exception import DestFileNewer
 from ..scan.exception import InvalidArgument
 from ..scan.folder import AbstractFolder
 from ..scan.path import AbstractPath
-from .action import B2CopyAction, B2DeleteAction, B2DownloadAction, B2HideAction, B2UploadAction, LocalDeleteAction
-from .encryption_provider import SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER, AbstractSyncEncryptionSettingsProvider
+from .action import (
+    B2CopyAction,
+    B2DeleteAction,
+    B2DownloadAction,
+    B2HideAction,
+    B2UploadAction,
+    LocalDeleteAction,
+)
+from .encryption_provider import (
+    SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+    AbstractSyncEncryptionSettingsProvider,
+)
 
 ONE_DAY_IN_MS = 24 * 60 * 60 * 1000
 
@@ -50,18 +66,18 @@ class AbstractFileSyncPolicy(metaclass=ABCMeta):
     SOURCE_PREFIX = NotImplemented
 
     def __init__(
-        self,
-        source_path: AbstractPath,
-        source_folder: AbstractFolder,
-        dest_path: AbstractPath,
-        dest_folder: AbstractFolder,
-        now_millis: int,
-        keep_days: int,
-        newer_file_mode: NewerFileSyncMode,
-        compare_threshold: int,
-        compare_version_mode: CompareVersionMode = CompareVersionMode.MODTIME,
-        encryption_settings_provider:
-        AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+            self,
+            source_path: AbstractPath,
+            source_folder: AbstractFolder,
+            dest_path: AbstractPath,
+            dest_folder: AbstractFolder,
+            now_millis: int,
+            keep_days: int,
+            newer_file_mode: NewerFileSyncMode,
+            compare_threshold: int,
+            compare_version_mode: CompareVersionMode = CompareVersionMode.MODTIME,
+            encryption_settings_provider:
+            AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
     ):
         """
         :param b2sdk.v2.AbstractPath source_path: source file object
@@ -109,12 +125,12 @@ class AbstractFileSyncPolicy(metaclass=ABCMeta):
 
     @classmethod
     def files_are_different(
-        cls,
-        source_path: AbstractPath,
-        dest_path: AbstractPath,
-        compare_threshold: Optional[int] = None,
-        compare_version_mode: CompareVersionMode = CompareVersionMode.MODTIME,
-        newer_file_mode: NewerFileSyncMode = NewerFileSyncMode.RAISE_ERROR,
+            cls,
+            source_path: AbstractPath,
+            dest_path: AbstractPath,
+            compare_threshold: Optional[int] = None,
+            compare_version_mode: CompareVersionMode = CompareVersionMode.MODTIME,
+            newer_file_mode: NewerFileSyncMode = NewerFileSyncMode.RAISE_ERROR,
     ):
         """
         Compare two files and determine if the the destination file
@@ -262,10 +278,10 @@ class UpAndDeletePolicy(UpPolicy):
         for action in super(UpAndDeletePolicy, self)._get_hide_delete_actions():
             yield action
         for action in make_b2_delete_actions(
-            self._source_path,
-            self._dest_path,
-            self._dest_folder,
-            self._transferred,
+                self._source_path,
+                self._dest_path,
+                self._dest_folder,
+                self._transferred,
         ):
             yield action
 
@@ -279,12 +295,12 @@ class UpAndKeepDaysPolicy(UpPolicy):
         for action in super(UpAndKeepDaysPolicy, self)._get_hide_delete_actions():
             yield action
         for action in make_b2_keep_days_actions(
-            self._source_path,
-            self._dest_path,
-            self._dest_folder,
-            self._transferred,
-            self._keep_days,
-            self._now_millis,
+                self._source_path,
+                self._dest_path,
+                self._dest_folder,
+                self._transferred,
+                self._keep_days,
+                self._now_millis,
         ):
             yield action
 
@@ -298,7 +314,7 @@ class DownAndDeletePolicy(DownPolicy):
         for action in super(DownAndDeletePolicy, self)._get_hide_delete_actions():
             yield action
         if self._dest_path is not None and (
-            self._source_path is None or not self._source_path.is_visible()
+                self._source_path is None or not self._source_path.is_visible()
         ):
             yield LocalDeleteAction(
                 self._dest_path.relative_path,
@@ -321,7 +337,6 @@ class CopyPolicy(AbstractFileSyncPolicy):
     SOURCE_PREFIX = 'b2://'
 
     def _make_transfer_action(self):
-
         return B2CopyAction(
             self._source_folder.make_full_path(self._source_path.relative_path),
             self._source_path,
@@ -341,10 +356,10 @@ class CopyAndDeletePolicy(CopyPolicy):
         for action in super()._get_hide_delete_actions():
             yield action
         for action in make_b2_delete_actions(
-            self._source_path,
-            self._dest_path,
-            self._dest_folder,
-            self._transferred,
+                self._source_path,
+                self._dest_path,
+                self._dest_folder,
+                self._transferred,
         ):
             yield action
 
@@ -358,12 +373,12 @@ class CopyAndKeepDaysPolicy(CopyPolicy):
         for action in super()._get_hide_delete_actions():
             yield action
         for action in make_b2_keep_days_actions(
-            self._source_path,
-            self._dest_path,
-            self._dest_folder,
-            self._transferred,
-            self._keep_days,
-            self._now_millis,
+                self._source_path,
+                self._dest_path,
+                self._dest_folder,
+                self._transferred,
+                self._keep_days,
+                self._now_millis,
         ):
             yield action
 
@@ -385,10 +400,10 @@ def make_b2_delete_note(version, index, transferred):
 
 
 def make_b2_delete_actions(
-    source_path: AbstractPath,
-    dest_path: AbstractPath,
-    dest_folder: AbstractFolder,
-    transferred: bool,
+        source_path: AbstractPath,
+        dest_path: AbstractPath,
+        dest_folder: AbstractFolder,
+        transferred: bool,
 ):
     """
     Create the actions to delete files stored on B2, which are not present locally.
@@ -414,12 +429,12 @@ def make_b2_delete_actions(
 
 
 def make_b2_keep_days_actions(
-    source_path: AbstractPath,
-    dest_path: AbstractPath,
-    dest_folder: AbstractFolder,
-    transferred: bool,
-    keep_days: int,
-    now_millis: int,
+        source_path: AbstractPath,
+        dest_path: AbstractPath,
+        dest_folder: AbstractFolder,
+        transferred: bool,
+        keep_days: int,
+        now_millis: int,
 ):
     """
     Create the actions to hide or delete existing versions of a file

--- a/b2sdk/sync/policy_manager.py
+++ b/b2sdk/sync/policy_manager.py
@@ -9,9 +9,17 @@
 ######################################################################
 
 from ..scan.path import AbstractPath
-from .policy import CopyAndDeletePolicy, CopyAndKeepDaysPolicy, CopyPolicy, \
-    DownAndDeletePolicy, DownAndKeepDaysPolicy, DownPolicy, UpAndDeletePolicy, \
-    UpAndKeepDaysPolicy, UpPolicy
+from .policy import (
+    CopyAndDeletePolicy,
+    CopyAndKeepDaysPolicy,
+    CopyPolicy,
+    DownAndDeletePolicy,
+    DownAndKeepDaysPolicy,
+    DownPolicy,
+    UpAndDeletePolicy,
+    UpAndKeepDaysPolicy,
+    UpPolicy,
+)
 
 
 class SyncPolicyManager:
@@ -24,19 +32,19 @@ class SyncPolicyManager:
         self.policies = {}  # dict<,>
 
     def get_policy(
-        self,
-        sync_type,
-        source_path: AbstractPath,
-        source_folder,
-        dest_path: AbstractPath,
-        dest_folder,
-        now_millis,
-        delete,
-        keep_days,
-        newer_file_mode,
-        compare_threshold,
-        compare_version_mode,
-        encryption_settings_provider,
+            self,
+            sync_type,
+            source_path: AbstractPath,
+            source_folder,
+            dest_path: AbstractPath,
+            dest_folder,
+            now_millis,
+            delete,
+            keep_days,
+            newer_file_mode,
+            compare_threshold,
+            compare_version_mode,
+            encryption_settings_provider,
     ):
         """
         Return a policy object.

--- a/b2sdk/sync/report.py
+++ b/b2sdk/sync/report.py
@@ -15,7 +15,10 @@ from dataclasses import dataclass
 
 from ..progress import AbstractProgressListener
 from ..scan.report import ProgressReport
-from ..utils import format_and_scale_fraction, format_and_scale_number
+from ..utils import (
+    format_and_scale_fraction,
+    format_and_scale_number,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/b2sdk/sync/sync.py
+++ b/b2sdk/sync/sync.py
@@ -11,7 +11,10 @@
 import concurrent.futures as futures
 import logging
 
-from enum import Enum, unique
+from enum import (
+    Enum,
+    unique,
+)
 
 from ..bounded_queue_executor import BoundedQueueExecutor
 from ..scan.exception import InvalidArgument
@@ -19,10 +22,19 @@ from ..scan.folder import AbstractFolder
 from ..scan.path import AbstractPath
 from ..scan.policies import DEFAULT_SCAN_MANAGER
 from ..scan.scan import zip_folders
-from .encryption_provider import SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER, AbstractSyncEncryptionSettingsProvider
+from .encryption_provider import (
+    SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+    AbstractSyncEncryptionSettingsProvider,
+)
 from .exception import IncompleteSync
-from .policy import CompareVersionMode, NewerFileSyncMode
-from .policy_manager import POLICY_MANAGER, SyncPolicyManager
+from .policy import (
+    CompareVersionMode,
+    NewerFileSyncMode,
+)
+from .policy_manager import (
+    POLICY_MANAGER,
+    SyncPolicyManager,
+)
 from .report import SyncReport
 
 logger = logging.getLogger(__name__)
@@ -76,17 +88,17 @@ class Synchronizer:
     """
 
     def __init__(
-        self,
-        max_workers,
-        policies_manager=DEFAULT_SCAN_MANAGER,
-        dry_run=False,
-        allow_empty_source=False,
-        newer_file_mode=NewerFileSyncMode.RAISE_ERROR,
-        keep_days_or_delete=KeepOrDeleteMode.NO_DELETE,
-        compare_version_mode=CompareVersionMode.MODTIME,
-        compare_threshold=None,
-        keep_days=None,
-        sync_policy_manager: SyncPolicyManager = POLICY_MANAGER,
+            self,
+            max_workers,
+            policies_manager=DEFAULT_SCAN_MANAGER,
+            dry_run=False,
+            allow_empty_source=False,
+            newer_file_mode=NewerFileSyncMode.RAISE_ERROR,
+            keep_days_or_delete=KeepOrDeleteMode.NO_DELETE,
+            compare_version_mode=CompareVersionMode.MODTIME,
+            compare_threshold=None,
+            keep_days=None,
+            sync_policy_manager: SyncPolicyManager = POLICY_MANAGER,
     ):
         """
         Initialize synchronizer class and validate arguments
@@ -143,13 +155,13 @@ class Synchronizer:
             )
 
     def sync_folders(
-        self,
-        source_folder,
-        dest_folder,
-        now_millis,
-        reporter,
-        encryption_settings_provider:
-        AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+            self,
+            source_folder,
+            dest_folder,
+            now_millis,
+            reporter,
+            encryption_settings_provider:
+            AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
     ):
         """
         Syncs two folders.  Always ensures that every file in the
@@ -201,12 +213,12 @@ class Synchronizer:
 
         # Schedule each of the actions.
         for action in self._make_folder_sync_actions(
-            source_folder,
-            dest_folder,
-            now_millis,
-            reporter,
-            self.policies_manager,
-            encryption_settings_provider,
+                source_folder,
+                dest_folder,
+                now_millis,
+                reporter,
+                self.policies_manager,
+                encryption_settings_provider,
         ):
             logging.debug('scheduling action %s on bucket %s', action, action_bucket)
             sync_executor.submit(action.run, action_bucket, reporter, self.dry_run)
@@ -217,14 +229,14 @@ class Synchronizer:
             raise IncompleteSync('sync is incomplete')
 
     def _make_folder_sync_actions(
-        self,
-        source_folder: AbstractFolder,
-        dest_folder: AbstractFolder,
-        now_millis: int,
-        reporter: SyncReport,
-        policies_manager: SyncPolicyManager = DEFAULT_SCAN_MANAGER,
-        encryption_settings_provider:
-        AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+            self,
+            source_folder: AbstractFolder,
+            dest_folder: AbstractFolder,
+            now_millis: int,
+            reporter: SyncReport,
+            policies_manager: SyncPolicyManager = DEFAULT_SCAN_MANAGER,
+            encryption_settings_provider:
+            AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
     ):
         """
         Yield a sequence of actions that will sync the destination
@@ -250,10 +262,10 @@ class Synchronizer:
         total_files = 0
         total_bytes = 0
         for source_path, dest_path in zip_folders(
-            source_folder,
-            dest_folder,
-            reporter,
-            policies_manager,
+                source_folder,
+                dest_folder,
+                reporter,
+                policies_manager,
         ):
             if source_path is None:
                 logger.debug('determined that %s is not present on source', dest_path)
@@ -268,13 +280,13 @@ class Synchronizer:
                 reporter.update_compare(1)
 
             for action in self._make_file_sync_actions(
-                sync_type,
-                source_path,
-                dest_path,
-                source_folder,
-                dest_folder,
-                now_millis,
-                encryption_settings_provider,
+                    sync_type,
+                    source_path,
+                    dest_path,
+                    source_folder,
+                    dest_folder,
+                    now_millis,
+                    encryption_settings_provider,
             ):
                 total_files += 1
                 total_bytes += action.get_bytes()
@@ -288,15 +300,15 @@ class Synchronizer:
             reporter.end_compare(total_files, total_bytes)
 
     def _make_file_sync_actions(
-        self,
-        sync_type: str,
-        source_path: AbstractPath,
-        dest_path: AbstractPath,
-        source_folder: AbstractFolder,
-        dest_folder: AbstractFolder,
-        now_millis: int,
-        encryption_settings_provider:
-        AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+            self,
+            sync_type: str,
+            source_path: AbstractPath,
+            dest_path: AbstractPath,
+            source_folder: AbstractFolder,
+            dest_folder: AbstractFolder,
+            now_millis: int,
+            encryption_settings_provider:
+            AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
     ):
         """
         Yields the sequence of actions needed to sync the two files

--- a/b2sdk/transfer/emerge/emerger.py
+++ b/b2sdk/transfer/emerge/emerger.py
@@ -12,7 +12,10 @@ import logging
 from typing import Optional
 
 from b2sdk.encryption.setting import EncryptionSetting
-from b2sdk.file_lock import FileRetentionSetting, LegalHold
+from b2sdk.file_lock import (
+    FileRetentionSetting,
+    LegalHold,
+)
 from b2sdk.utils import B2TraceMetaAbstract
 from b2sdk.transfer.emerge.executor import EmergeExecutor
 from b2sdk.transfer.emerge.planner.planner import EmergePlanner
@@ -41,20 +44,20 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         self.emerge_executor = EmergeExecutor(services)
 
     def emerge(
-        self,
-        bucket_id,
-        write_intents,
-        file_name,
-        content_type,
-        file_info,
-        progress_listener,
-        recommended_upload_part_size=None,
-        continue_large_file_id=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        min_part_size=None,
-        max_part_size=None,
+            self,
+            bucket_id,
+            write_intents,
+            file_name,
+            content_type,
+            file_info,
+            progress_listener,
+            recommended_upload_part_size=None,
+            continue_large_file_id=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            min_part_size=None,
+            max_part_size=None,
     ):
         """
         Create a new file (object in the cloud, really) from an iterable (list, tuple etc) of write intents.
@@ -93,21 +96,21 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         )
 
     def emerge_stream(
-        self,
-        bucket_id,
-        write_intent_iterator,
-        file_name,
-        content_type,
-        file_info,
-        progress_listener,
-        recommended_upload_part_size=None,
-        continue_large_file_id=None,
-        max_queue_size=DEFAULT_STREAMING_MAX_QUEUE_SIZE,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        min_part_size=None,
-        max_part_size=None,
+            self,
+            bucket_id,
+            write_intent_iterator,
+            file_name,
+            content_type,
+            file_info,
+            progress_listener,
+            recommended_upload_part_size=None,
+            continue_large_file_id=None,
+            max_queue_size=DEFAULT_STREAMING_MAX_QUEUE_SIZE,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            min_part_size=None,
+            max_part_size=None,
     ):
         """
         Create a new file (object in the cloud, really) from a stream of write intents.
@@ -153,10 +156,10 @@ class Emerger(metaclass=B2TraceMetaAbstract):
         )
 
     def get_emerge_planner(
-        self,
-        recommended_upload_part_size=None,
-        min_part_size=None,
-        max_part_size=None,
+            self,
+            recommended_upload_part_size=None,
+            min_part_size=None,
+            max_part_size=None,
     ):
         return EmergePlanner.from_account_info(
             self.services.session.account_info,

--- a/b2sdk/transfer/emerge/executor.py
+++ b/b2sdk/transfer/emerge/executor.py
@@ -10,12 +10,19 @@
 
 import threading
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from typing import Optional
 
 from b2sdk.encryption.setting import EncryptionSetting
 from b2sdk.exception import MaxFileSizeExceeded
-from b2sdk.file_lock import FileRetentionSetting, LegalHold, NO_RETENTION_FILE_SETTING
+from b2sdk.file_lock import (
+    FileRetentionSetting,
+    LegalHold,
+    NO_RETENTION_FILE_SETTING,
+)
 from b2sdk.transfer.outbound.large_file_upload_state import LargeFileUploadState
 from b2sdk.transfer.outbound.upload_source import UploadSourceStream
 
@@ -27,18 +34,18 @@ class EmergeExecutor:
         self.services = services
 
     def execute_emerge_plan(
-        self,
-        emerge_plan,
-        bucket_id,
-        file_name,
-        content_type,
-        file_info,
-        progress_listener,
-        continue_large_file_id=None,
-        max_queue_size=None,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            emerge_plan,
+            bucket_id,
+            file_name,
+            content_type,
+            file_info,
+            progress_listener,
+            continue_large_file_id=None,
+            max_queue_size=None,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         if emerge_plan.is_large_file():
             execution = LargeFileEmergeExecution(
@@ -75,16 +82,16 @@ class BaseEmergeExecution(metaclass=ABCMeta):
     DEFAULT_CONTENT_TYPE = AUTO_CONTENT_TYPE
 
     def __init__(
-        self,
-        services,
-        bucket_id,
-        file_name,
-        content_type,
-        file_info,
-        progress_listener,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            services,
+            bucket_id,
+            file_name,
+            content_type,
+            file_info,
+            progress_listener,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         self.services = services
         self.bucket_id = bucket_id
@@ -116,18 +123,18 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
     MAX_LARGE_FILE_SIZE = 10 * 1000 * 1000 * 1000 * 1000  # 10 TB
 
     def __init__(
-        self,
-        services,
-        bucket_id,
-        file_name,
-        content_type,
-        file_info,
-        progress_listener,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        continue_large_file_id=None,
-        max_queue_size=None,
+            self,
+            services,
+            bucket_id,
+            file_name,
+            content_type,
+            file_info,
+            progress_listener,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            continue_large_file_id=None,
+            max_queue_size=None,
     ):
         super(LargeFileEmergeExecution, self).__init__(
             services,
@@ -235,15 +242,15 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
             return future
 
     def _get_unfinished_file_and_parts(
-        self,
-        bucket_id,
-        file_name,
-        file_info,
-        continue_large_file_id,
-        encryption: EncryptionSetting,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        emerge_parts_dict=None,
+            self,
+            bucket_id,
+            file_name,
+            file_info,
+            continue_large_file_id,
+            encryption: EncryptionSetting,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            emerge_parts_dict=None,
     ):
         if 'listFiles' not in self.services.session.account_info.get_allowed()['capabilities']:
             return None, {}
@@ -289,14 +296,14 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         return unfinished_file, finished_parts
 
     def _find_unfinished_file_by_plan_id(
-        self,
-        bucket_id,
-        file_name,
-        file_info,
-        emerge_parts_dict,
-        encryption: EncryptionSetting,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            bucket_id,
+            file_name,
+            file_info,
+            emerge_parts_dict,
+            encryption: EncryptionSetting,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         file_retention = file_retention or NO_RETENTION_FILE_SETTING
         assert 'plan_id' in file_info
@@ -304,7 +311,7 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         best_match_parts = {}
         best_match_parts_len = 0
         for file_ in self.services.large_file.list_unfinished_large_files(
-            bucket_id, prefix=file_name
+                bucket_id, prefix=file_name
         ):
             if file_.file_info != file_info:
                 continue
@@ -346,14 +353,14 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         return best_match_file, best_match_parts
 
     def _match_unfinished_file_if_possible(
-        self,
-        bucket_id,
-        file_name,
-        file_info,
-        emerge_parts_dict,
-        encryption: EncryptionSetting,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            bucket_id,
+            file_name,
+            file_info,
+            emerge_parts_dict,
+            encryption: EncryptionSetting,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         """
         Find an unfinished file that may be used to resume a large file upload.  The
@@ -364,7 +371,7 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         """
         file_retention = file_retention or NO_RETENTION_FILE_SETTING
         for file_ in self.services.large_file.list_unfinished_large_files(
-            bucket_id, prefix=file_name
+                bucket_id, prefix=file_name
         ):
             if file_.file_name != file_name:
                 continue
@@ -451,13 +458,13 @@ class SmallFileEmergeExecutionStepFactory(BaseExecutionStepFactory):
 
 class LargeFileEmergeExecutionStepFactory(BaseExecutionStepFactory):
     def __init__(
-        self,
-        emerge_execution,
-        emerge_part,
-        part_number,
-        large_file_id,
-        large_file_upload_state,
-        finished_parts=None,
+            self,
+            emerge_execution,
+            emerge_part,
+            part_number,
+            large_file_id,
+            large_file_upload_state,
+            finished_parts=None,
     ):
         super(LargeFileEmergeExecutionStepFactory, self).__init__(emerge_execution, emerge_part)
         self.part_number = part_number
@@ -526,13 +533,13 @@ class CopyFileExecutionStep(BaseExecutionStep):
 
 class CopyPartExecutionStep(BaseExecutionStep):
     def __init__(
-        self,
-        emerge_execution,
-        copy_source_range,
-        part_number,
-        large_file_id,
-        large_file_upload_state,
-        finished_parts=None
+            self,
+            emerge_execution,
+            copy_source_range,
+            part_number,
+            large_file_id,
+            large_file_upload_state,
+            finished_parts=None
     ):
         super().__init__(emerge_execution)
         self.copy_source_range = copy_source_range
@@ -582,15 +589,15 @@ class UploadFileExecutionStep(BaseExecutionStep):
 
 class UploadPartExecutionStep(BaseExecutionStep):
     def __init__(
-        self,
-        emerge_execution,
-        stream_opener,
-        part_number,
-        large_file_id,
-        large_file_upload_state,
-        stream_length=None,
-        stream_sha1=None,
-        finished_parts=None
+            self,
+            emerge_execution,
+            stream_opener,
+            part_number,
+            large_file_id,
+            large_file_upload_state,
+            stream_length=None,
+            stream_sha1=None,
+            finished_parts=None
     ):
         super().__init__(emerge_execution)
         self.stream_opener = stream_opener

--- a/b2sdk/transfer/emerge/planner/part_definition.py
+++ b/b2sdk/transfer/emerge/planner/part_definition.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from functools import partial
 
 from b2sdk.stream.chained import ChainedStream

--- a/b2sdk/transfer/emerge/planner/planner.py
+++ b/b2sdk/transfer/emerge/planner/planner.py
@@ -12,7 +12,10 @@ from math import ceil
 import hashlib
 import json
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from collections import deque
 from itertools import chain
 
@@ -87,10 +90,10 @@ class EmergePlanner:
     DEFAULT_MAX_PART_SIZE = 5 * GIGABYTE
 
     def __init__(
-        self,
-        min_part_size=None,
-        recommended_upload_part_size=None,
-        max_part_size=None,
+            self,
+            min_part_size=None,
+            recommended_upload_part_size=None,
+            max_part_size=None,
     ):
         self.min_part_size = min_part_size or self.DEFAULT_MIN_PART_SIZE
         self.recommended_upload_part_size = recommended_upload_part_size or self.DEFAULT_RECOMMENDED_UPLOAD_PART_SIZE
@@ -99,11 +102,11 @@ class EmergePlanner:
 
     @classmethod
     def from_account_info(
-        cls,
-        account_info,
-        min_part_size=None,
-        recommended_upload_part_size=None,
-        max_part_size=None
+            cls,
+            account_info,
+            min_part_size=None,
+            recommended_upload_part_size=None,
+            max_part_size=None
     ):
         if recommended_upload_part_size is None:
             recommended_upload_part_size = account_info.get_recommended_part_size()
@@ -511,18 +514,18 @@ class IntentsState:
             return
 
         if (
-            self._current_intent is None and self._next_intent is not None and (
+                self._current_intent is None and self._next_intent is not None and (
                 self._next_intent.destination_offset != effective_incoming_offset or
                 incoming_offset is None
-            )
+        )
         ):
             self._set_current_intent(self._next_intent, last_sent_offset)
             self._set_next_intent(None)
 
         # current and next can be both not None at this point only if they overlap
         if (
-            self._current_intent is not None and self._next_intent is not None and
-            effective_incoming_offset > self._current_intent_end
+                self._current_intent is not None and self._next_intent is not None and
+                effective_incoming_offset > self._current_intent_end
         ):
             # incoming intent does not overlap with current intent
             # so we switch to next because we are sure that we will have to use it anyway
@@ -535,7 +538,7 @@ class IntentsState:
                 self._set_next_intent(None)
             else:
                 remaining_len = self.protected_intent_length - (
-                    last_sent_offset - self._current_intent_start
+                        last_sent_offset - self._current_intent_start
                 )
                 if remaining_len > 0:
                     last_sent_offset += remaining_len

--- a/b2sdk/transfer/emerge/planner/upload_subpart.py
+++ b/b2sdk/transfer/emerge/planner/upload_subpart.py
@@ -10,7 +10,10 @@
 
 import io
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from functools import partial
 
 from b2sdk.stream.chained import StreamOpener

--- a/b2sdk/transfer/inbound/download_manager.py
+++ b/b2sdk/transfer/inbound/download_manager.py
@@ -39,17 +39,17 @@ class DownloadManager(TransferManager, ThreadPoolMixin, metaclass=B2TraceMetaAbs
     # block size used when downloading file. If it is set to a high value,
     # progress reporting will be jumpy, if it's too low, it impacts CPU
     MIN_CHUNK_SIZE = 8192  # ~1MB file will show ~1% progress increment
-    MAX_CHUNK_SIZE = 1024**2
+    MAX_CHUNK_SIZE = 1024 ** 2
 
     PARALLEL_DOWNLOADER_CLASS = staticmethod(ParallelDownloader)
     SIMPLE_DOWNLOADER_CLASS = staticmethod(SimpleDownloader)
 
     def __init__(
-        self,
-        write_buffer_size: Optional[int] = None,
-        check_hash: bool = True,
-        max_download_streams_per_file: Optional[int] = None,
-        **kwargs
+            self,
+            write_buffer_size: Optional[int] = None,
+            check_hash: bool = True,
+            max_download_streams_per_file: Optional[int] = None,
+            **kwargs
     ):
         """
         Initialize the DownloadManager using the given services object.
@@ -78,11 +78,11 @@ class DownloadManager(TransferManager, ThreadPoolMixin, metaclass=B2TraceMetaAbs
         self.check_hash = check_hash
 
     def download_file_from_url(
-        self,
-        url,
-        progress_listener=None,
-        range_=None,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            url,
+            progress_listener=None,
+            range_=None,
+            encryption: Optional[EncryptionSetting] = None,
     ) -> DownloadedFile:
         """
         :param url: url from which the file should be downloaded
@@ -92,9 +92,9 @@ class DownloadManager(TransferManager, ThreadPoolMixin, metaclass=B2TraceMetaAbs
         """
         progress_listener = progress_listener or DoNothingProgressListener()
         with self.services.session.download_file_from_url(
-            url,
-            range_=range_,
-            encryption=encryption,
+                url,
+                range_=range_,
+                encryption=encryption,
         ) as response:
             download_version = self.services.api.download_version_factory.from_response_headers(
                 response.headers

--- a/b2sdk/transfer/inbound/downloaded_file.py
+++ b/b2sdk/transfer/inbound/downloaded_file.py
@@ -10,7 +10,11 @@
 
 import io
 import logging
-from typing import Optional, Tuple, TYPE_CHECKING
+from typing import (
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+)
 
 from requests.models import Response
 
@@ -90,15 +94,15 @@ class DownloadedFile:
     """
 
     def __init__(
-        self,
-        download_version: DownloadVersion,
-        download_manager: 'DownloadManager',
-        range_: Optional[Tuple[int, int]],
-        response: Response,
-        encryption: Optional[EncryptionSetting],
-        progress_listener: AbstractProgressListener,
-        write_buffer_size=None,
-        check_hash=True,
+            self,
+            download_version: DownloadVersion,
+            download_manager: 'DownloadManager',
+            range_: Optional[Tuple[int, int]],
+            response: Response,
+            encryption: Optional[EncryptionSetting],
+            progress_listener: AbstractProgressListener,
+            write_buffer_size=None,
+            check_hash=True,
     ):
         self.download_version = download_version
         self.download_manager = download_manager
@@ -118,8 +122,8 @@ class DownloadedFile:
                 raise TruncatedOutput(bytes_read, self.download_version.content_length)
 
             if (
-                self.check_hash and self.download_version.content_sha1 != 'none' and
-                actual_sha1 != self.download_version.content_sha1
+                    self.check_hash and self.download_version.content_sha1 != 'none' and
+                    actual_sha1 != self.download_version.content_sha1
             ):
                 raise ChecksumMismatch(
                     checksum_type='sha1',
@@ -171,9 +175,9 @@ class DownloadedFile:
                               (parallel strategies) will be discarded.
         """
         with MtimeUpdatedFile(
-            path_,
-            mod_time_millis=self.download_version.mod_time_millis,
-            mode=mode,
-            buffering=self.write_buffer_size,
+                path_,
+                mod_time_millis=self.download_version.mod_time_millis,
+                mode=mode,
+                buffering=self.write_buffer_size,
         ) as file:
             self.save(file, allow_seeking=allow_seeking)

--- a/b2sdk/transfer/inbound/downloader/abstract.py
+++ b/b2sdk/transfer/inbound/downloader/abstract.py
@@ -48,19 +48,19 @@ class AbstractDownloader(metaclass=B2TraceMetaAbstract):
     DEFAULT_ALIGN_FACTOR = 4096
 
     def __init__(
-        self,
-        thread_pool: Optional[ThreadPoolExecutor] = None,
-        force_chunk_size: Optional[int] = None,
-        min_chunk_size: Optional[int] = None,
-        max_chunk_size: Optional[int] = None,
-        align_factor: Optional[int] = None,
-        check_hash: bool = True,
-        **kwargs
+            self,
+            thread_pool: Optional[ThreadPoolExecutor] = None,
+            force_chunk_size: Optional[int] = None,
+            min_chunk_size: Optional[int] = None,
+            max_chunk_size: Optional[int] = None,
+            align_factor: Optional[int] = None,
+            check_hash: bool = True,
+            **kwargs
     ):
         align_factor = align_factor or self.DEFAULT_ALIGN_FACTOR
         assert force_chunk_size is not None or (
-            min_chunk_size is not None and max_chunk_size is not None and
-            0 < min_chunk_size <= max_chunk_size and max_chunk_size >= align_factor
+                min_chunk_size is not None and max_chunk_size is not None and
+                0 < min_chunk_size <= max_chunk_size and max_chunk_size >= align_factor
         )
         self._min_chunk_size = min_chunk_size
         self._max_chunk_size = max_chunk_size
@@ -108,12 +108,12 @@ class AbstractDownloader(metaclass=B2TraceMetaAbstract):
 
     @abstractmethod
     def download(
-        self,
-        file: IOBase,
-        response: Response,
-        download_version: DownloadVersion,
-        session: B2Session,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            file: IOBase,
+            response: Response,
+            download_version: DownloadVersion,
+            session: B2Session,
+            encryption: Optional[EncryptionSetting] = None,
     ):
         """
         @returns (bytes_read, actual_sha1)

--- a/b2sdk/transfer/inbound/downloader/parallel.py
+++ b/b2sdk/transfer/inbound/downloader/parallel.py
@@ -48,7 +48,7 @@ class ParallelDownloader(AbstractDownloader):
     #      |                                                                     |
     #      cloud file start                                         cloud file end
     #
-    FINISH_HASHING_BUFFER_SIZE = 1024**2
+    FINISH_HASHING_BUFFER_SIZE = 1024 ** 2
 
     def __init__(self, min_part_size: int, max_streams: Optional[int] = None, **kwargs):
         """
@@ -77,12 +77,12 @@ class ParallelDownloader(AbstractDownloader):
         return num_streams
 
     def download(
-        self,
-        file: IOBase,
-        response: Response,
-        download_version: DownloadVersion,
-        session: B2Session,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            file: IOBase,
+            response: Response,
+            download_version: DownloadVersion,
+            session: B2Session,
+            encryption: Optional[EncryptionSetting] = None,
     ):
         """
         Download a file from given url using parallel download sessions and stores it in the given download_destination.
@@ -155,8 +155,8 @@ class ParallelDownloader(AbstractDownloader):
                 break
 
     def _get_parts(
-        self, response, session, writer, hasher, first_part, parts_to_download, chunk_size,
-        encryption
+            self, response, session, writer, hasher, first_part, parts_to_download, chunk_size,
+            encryption
     ):
         stream = self._thread_pool.submit(
             download_first_part,
@@ -252,13 +252,13 @@ class WriterThread(threading.Thread):
 
 
 def download_first_part(
-    response: Response,
-    hasher,
-    session: B2Session,
-    writer: WriterThread,
-    first_part: 'PartToDownload',
-    chunk_size: int,
-    encryption: Optional[EncryptionSetting] = None,
+        response: Response,
+        hasher,
+        session: B2Session,
+        writer: WriterThread,
+        first_part: 'PartToDownload',
+        chunk_size: int,
+        encryption: Optional[EncryptionSetting] = None,
 ) -> None:
     """
     :param response: response of the original GET call
@@ -334,9 +334,9 @@ def download_first_part(
             tries_left, bytes_read, cloud_range
         )
         with session.download_file_from_url(
-            url,
-            cloud_range.as_tuple(),
-            encryption=encryption,
+                url,
+                cloud_range.as_tuple(),
+                encryption=encryption,
         ) as response:
             before_read = perf_counter_ns()
             for to_write in response.iter_content(chunk_size=chunk_size):
@@ -359,12 +359,12 @@ def download_first_part(
 
 
 def download_non_first_part(
-    url: str,
-    session: B2Session,
-    writer: WriterThread,
-    part_to_download: 'PartToDownload',
-    chunk_size: int,
-    encryption: Optional[EncryptionSetting] = None,
+        url: str,
+        session: B2Session,
+        writer: WriterThread,
+        part_to_download: 'PartToDownload',
+        chunk_size: int,
+        encryption: Optional[EncryptionSetting] = None,
 ) -> None:
     """
     :param url: download URL
@@ -393,9 +393,9 @@ def download_non_first_part(
         stats_collector_write_append = stats_collector.write.append
         start = before_read = perf_counter_ns()
         with session.download_file_from_url(
-            url,
-            cloud_range.as_tuple(),
-            encryption=encryption,
+                url,
+                cloud_range.as_tuple(),
+                encryption=encryption,
         ) as response:
             before_read = perf_counter_ns()
             for to_write in response.iter_content(chunk_size=chunk_size):

--- a/b2sdk/transfer/inbound/downloader/simple.py
+++ b/b2sdk/transfer/inbound/downloader/simple.py
@@ -27,12 +27,12 @@ class SimpleDownloader(AbstractDownloader):
     REQUIRES_SEEKING = False
 
     def _download(
-        self,
-        file: IOBase,
-        response: Response,
-        download_version: DownloadVersion,
-        session: B2Session,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            file: IOBase,
+            response: Response,
+            download_version: DownloadVersion,
+            session: B2Session,
+            encryption: Optional[EncryptionSetting] = None,
     ):
         actual_size = self._get_remote_range(response, download_version).size()
         chunk_size = self._get_chunk_size(actual_size)
@@ -65,12 +65,12 @@ class SimpleDownloader(AbstractDownloader):
                 retries_left, bytes_read, new_range
             )
             with session.download_file_from_url(
-                response.request.url,
-                new_range.as_tuple(),
-                encryption=encryption,
+                    response.request.url,
+                    new_range.as_tuple(),
+                    encryption=encryption,
             ) as followup_response:
                 for data in followup_response.iter_content(
-                    chunk_size=self._get_chunk_size(actual_size)
+                        chunk_size=self._get_chunk_size(actual_size)
                 ):
                     file.write(data)
                     digest.update(data)
@@ -79,12 +79,12 @@ class SimpleDownloader(AbstractDownloader):
         return bytes_read, digest.hexdigest()
 
     def download(
-        self,
-        file: IOBase,
-        response: Response,
-        download_version: DownloadVersion,
-        session: B2Session,
-        encryption: Optional[EncryptionSetting] = None,
+            self,
+            file: IOBase,
+            response: Response,
+            download_version: DownloadVersion,
+            session: B2Session,
+            encryption: Optional[EncryptionSetting] = None,
     ):
         future = self._thread_pool.submit(
             self._download, file, response, download_version, session, encryption

--- a/b2sdk/transfer/inbound/downloader/stats_collector.py
+++ b/b2sdk/transfer/inbound/downloader/stats_collector.py
@@ -9,7 +9,10 @@
 ######################################################################
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import (
+    dataclass,
+    field,
+)
 from typing import List  # 3.7 doesn't understand `list` vs `List`
 from typing import Optional
 

--- a/b2sdk/transfer/outbound/copy_manager.py
+++ b/b2sdk/transfer/outbound/copy_manager.py
@@ -11,10 +11,20 @@
 import logging
 from typing import Optional
 
-from b2sdk.encryption.setting import EncryptionMode, EncryptionSetting
+from b2sdk.encryption.setting import (
+    EncryptionMode,
+    EncryptionSetting,
+)
 from b2sdk.http_constants import SSE_C_KEY_ID_FILE_INFO_KEY_NAME
-from b2sdk.exception import AlreadyFailed, CopyArgumentsMismatch, SSECKeyIdMismatchInCopy
-from b2sdk.file_lock import FileRetentionSetting, LegalHold
+from b2sdk.exception import (
+    AlreadyFailed,
+    CopyArgumentsMismatch,
+    SSECKeyIdMismatchInCopy,
+)
+from b2sdk.file_lock import (
+    FileRetentionSetting,
+    LegalHold,
+)
 from b2sdk.raw_api import MetadataDirectiveMode
 from b2sdk.transfer.transfer_manager import TransferManager
 from b2sdk.utils.thread_pool import ThreadPoolMixin
@@ -34,17 +44,17 @@ class CopyManager(TransferManager, ThreadPoolMixin):
         return self.services.session.account_info
 
     def copy_file(
-        self,
-        copy_source,
-        file_name,
-        content_type,
-        file_info,
-        destination_bucket_id,
-        progress_listener,
-        destination_encryption: Optional[EncryptionSetting] = None,
-        source_encryption: Optional[EncryptionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
+            self,
+            copy_source,
+            file_name,
+            content_type,
+            file_info,
+            destination_bucket_id,
+            progress_listener,
+            destination_encryption: Optional[EncryptionSetting] = None,
+            source_encryption: Optional[EncryptionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
     ):
         # Run small copies in the same thread pool as large file copies,
         # so that they share resources during a sync.
@@ -63,14 +73,14 @@ class CopyManager(TransferManager, ThreadPoolMixin):
         )
 
     def copy_part(
-        self,
-        large_file_id,
-        part_copy_source,
-        part_number,
-        large_file_upload_state,
-        finished_parts=None,
-        destination_encryption: Optional[EncryptionSetting] = None,
-        source_encryption: Optional[EncryptionSetting] = None,
+            self,
+            large_file_id,
+            part_copy_source,
+            part_number,
+            large_file_upload_state,
+            finished_parts=None,
+            destination_encryption: Optional[EncryptionSetting] = None,
+            source_encryption: Optional[EncryptionSetting] = None,
     ):
         return self._thread_pool.submit(
             self._copy_part,
@@ -84,14 +94,14 @@ class CopyManager(TransferManager, ThreadPoolMixin):
         )
 
     def _copy_part(
-        self,
-        large_file_id,
-        part_copy_source,
-        part_number,
-        large_file_upload_state,
-        finished_parts,
-        destination_encryption: Optional[EncryptionSetting],
-        source_encryption: Optional[EncryptionSetting],
+            self,
+            large_file_id,
+            part_copy_source,
+            part_number,
+            large_file_upload_state,
+            finished_parts,
+            destination_encryption: Optional[EncryptionSetting],
+            source_encryption: Optional[EncryptionSetting],
     ):
         """
         Copy a file part to started large file.
@@ -119,7 +129,9 @@ class CopyManager(TransferManager, ThreadPoolMixin):
             large_file_upload_state.update_part_bytes(part.content_length)
 
             # Return SHA1 hash
-            return {'contentSha1': part.content_sha1}
+            return {
+                'contentSha1': part.content_sha1
+            }
 
         # if another part has already had an error there's no point in
         # uploading this part
@@ -138,17 +150,17 @@ class CopyManager(TransferManager, ThreadPoolMixin):
         return response
 
     def _copy_small_file(
-        self,
-        copy_source,
-        file_name,
-        content_type,
-        file_info,
-        destination_bucket_id,
-        progress_listener,
-        destination_encryption: Optional[EncryptionSetting],
-        source_encryption: Optional[EncryptionSetting],
-        legal_hold: Optional[LegalHold] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
+            self,
+            copy_source,
+            file_name,
+            content_type,
+            file_info,
+            destination_bucket_id,
+            progress_listener,
+            destination_encryption: Optional[EncryptionSetting],
+            source_encryption: Optional[EncryptionSetting],
+            legal_hold: Optional[LegalHold] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
     ):
         with progress_listener:
             progress_listener.set_total_bytes(copy_source.get_content_length() or 0)
@@ -197,14 +209,14 @@ class CopyManager(TransferManager, ThreadPoolMixin):
 
     @classmethod
     def establish_sse_c_file_metadata(
-        cls,
-        metadata_directive: MetadataDirectiveMode,
-        destination_file_info: Optional[dict],
-        destination_content_type: Optional[str],
-        destination_server_side_encryption: Optional[EncryptionSetting],
-        source_server_side_encryption: Optional[EncryptionSetting],
-        source_file_info: Optional[dict],
-        source_content_type: Optional[str],
+            cls,
+            metadata_directive: MetadataDirectiveMode,
+            destination_file_info: Optional[dict],
+            destination_content_type: Optional[str],
+            destination_server_side_encryption: Optional[EncryptionSetting],
+            source_server_side_encryption: Optional[EncryptionSetting],
+            source_file_info: Optional[dict],
+            source_content_type: Optional[str],
     ):
         assert metadata_directive in (MetadataDirectiveMode.REPLACE, MetadataDirectiveMode.COPY)
 

--- a/b2sdk/transfer/outbound/copy_source.py
+++ b/b2sdk/transfer/outbound/copy_source.py
@@ -16,13 +16,13 @@ from b2sdk.transfer.outbound.outbound_source import OutboundTransferSource
 
 class CopySource(OutboundTransferSource):
     def __init__(
-        self,
-        file_id,
-        offset=0,
-        length=None,
-        encryption: Optional[EncryptionSetting] = None,
-        source_file_info=None,
-        source_content_type=None,
+            self,
+            file_id,
+            offset=0,
+            length=None,
+            encryption: Optional[EncryptionSetting] = None,
+            source_file_info=None,
+            source_content_type=None,
     ):
         if not length and offset > 0:
             raise ValueError('Cannot copy with non zero offset and unknown or zero length')

--- a/b2sdk/transfer/outbound/outbound_source.py
+++ b/b2sdk/transfer/outbound/outbound_source.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 
 
 class OutboundTransferSource(metaclass=ABCMeta):

--- a/b2sdk/transfer/outbound/upload_manager.py
+++ b/b2sdk/transfer/outbound/upload_manager.py
@@ -12,13 +12,19 @@ import logging
 
 from typing import Optional
 
-from b2sdk.encryption.setting import EncryptionMode, EncryptionSetting
+from b2sdk.encryption.setting import (
+    EncryptionMode,
+    EncryptionSetting,
+)
 from b2sdk.exception import (
     AlreadyFailed,
     B2Error,
     MaxRetriesExceeded,
 )
-from b2sdk.file_lock import FileRetentionSetting, LegalHold
+from b2sdk.file_lock import (
+    FileRetentionSetting,
+    LegalHold,
+)
 from b2sdk.stream.progress import ReadingStreamWithProgress
 from b2sdk.stream.hashing import StreamWithHash
 from b2sdk.http_constants import HEX_DIGITS_AT_END
@@ -42,16 +48,16 @@ class UploadManager(TransferManager, ThreadPoolMixin):
         return self.services.session.account_info
 
     def upload_file(
-        self,
-        bucket_id,
-        upload_source,
-        file_name,
-        content_type,
-        file_info,
-        progress_listener,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            bucket_id,
+            upload_source,
+            file_name,
+            content_type,
+            file_info,
+            progress_listener,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         f = self._thread_pool.submit(
             self._upload_small_file,
@@ -68,14 +74,14 @@ class UploadManager(TransferManager, ThreadPoolMixin):
         return f
 
     def upload_part(
-        self,
-        bucket_id,
-        file_id,
-        part_upload_source,
-        part_number,
-        large_file_upload_state,
-        finished_parts=None,
-        encryption: EncryptionSetting = None,
+            self,
+            bucket_id,
+            file_id,
+            part_upload_source,
+            part_number,
+            large_file_upload_state,
+            finished_parts=None,
+            encryption: EncryptionSetting = None,
     ):
         f = self._thread_pool.submit(
             self._upload_part,
@@ -90,14 +96,14 @@ class UploadManager(TransferManager, ThreadPoolMixin):
         return f
 
     def _upload_part(
-        self,
-        bucket_id,
-        file_id,
-        part_upload_source,
-        part_number,
-        large_file_upload_state,
-        finished_parts,
-        encryption: EncryptionSetting,
+            self,
+            bucket_id,
+            file_id,
+            part_upload_source,
+            part_number,
+            large_file_upload_state,
+            finished_parts,
+            encryption: EncryptionSetting,
     ):
         """
         Upload a file part to started large file.
@@ -123,7 +129,9 @@ class UploadManager(TransferManager, ThreadPoolMixin):
             large_file_upload_state.update_part_bytes(part_upload_source.get_content_length())
 
             # Return SHA1 hash
-            return {'contentSha1': part.content_sha1}
+            return {
+                'contentSha1': part.content_sha1
+            }
 
         # Set up a progress listener
         part_progress_listener = PartProgressReporter(large_file_upload_state)
@@ -171,16 +179,16 @@ class UploadManager(TransferManager, ThreadPoolMixin):
         raise MaxRetriesExceeded(self.MAX_UPLOAD_ATTEMPTS, exception_list)
 
     def _upload_small_file(
-        self,
-        bucket_id,
-        upload_source,
-        file_name,
-        content_type,
-        file_info,
-        progress_listener,
-        encryption: Optional[EncryptionSetting] = None,
-        file_retention: Optional[FileRetentionSetting] = None,
-        legal_hold: Optional[LegalHold] = None,
+            self,
+            bucket_id,
+            upload_source,
+            file_name,
+            content_type,
+            file_info,
+            progress_listener,
+            encryption: Optional[EncryptionSetting] = None,
+            file_retention: Optional[FileRetentionSetting] = None,
+            legal_hold: Optional[LegalHold] = None,
     ):
         content_length = upload_source.get_content_length()
         exception_info_list = []

--- a/b2sdk/transfer/outbound/upload_source.py
+++ b/b2sdk/transfer/outbound/upload_source.py
@@ -15,9 +15,15 @@ import os
 from abc import abstractmethod
 
 from b2sdk.exception import InvalidUploadSource
-from b2sdk.stream.range import RangeOfInputStream, wrap_with_range
+from b2sdk.stream.range import (
+    RangeOfInputStream,
+    wrap_with_range,
+)
 from b2sdk.transfer.outbound.outbound_source import OutboundTransferSource
-from b2sdk.utils import hex_sha1_of_stream, hex_sha1_of_unlimited_stream
+from b2sdk.utils import (
+    hex_sha1_of_stream,
+    hex_sha1_of_unlimited_stream,
+)
 
 
 class AbstractUploadSource(OutboundTransferSource):
@@ -58,7 +64,7 @@ class UploadSourceBytes(AbstractUploadSource):
         return '<{classname} data={data} id={id}>'.format(
             classname=self.__class__.__name__,
             data=str(self.data_bytes[:20]) +
-            '...' if len(self.data_bytes) > 20 else self.data_bytes,
+                 '...' if len(self.data_bytes) > 20 else self.data_bytes,
             id=id(self),
         )
 

--- a/b2sdk/utils/__init__.py
+++ b/b2sdk/utils/__init__.py
@@ -18,9 +18,18 @@ import tempfile
 import time
 import concurrent.futures as futures
 from decimal import Decimal
-from urllib.parse import quote, unquote_plus
+from urllib.parse import (
+    quote,
+    unquote_plus,
+)
 
-from logfury.v1 import DefaultTraceAbstractMeta, DefaultTraceMeta, limit_trace_arguments, disable_trace, trace_call
+from logfury.v1 import (
+    DefaultTraceAbstractMeta,
+    DefaultTraceMeta,
+    limit_trace_arguments,
+    disable_trace,
+    trace_call,
+)
 
 
 def b2_url_encode(s):
@@ -298,7 +307,7 @@ def _pick_scale_and_suffix(x):
     if suffix == ' ':
         suffix = ''
 
-    scale = 1000**index
+    scale = 1000 ** index
     return (scale, suffix)
 
 

--- a/b2sdk/utils/thread_pool.py
+++ b/b2sdk/utils/thread_pool.py
@@ -21,10 +21,10 @@ class ThreadPoolMixin(metaclass=B2TraceMetaAbstract):
     DEFAULT_THREAD_POOL_CLASS = staticmethod(ThreadPoolExecutor)
 
     def __init__(
-        self,
-        thread_pool: Optional[ThreadPoolExecutor] = None,
-        max_workers: Optional[int] = None,
-        **kwargs
+            self,
+            thread_pool: Optional[ThreadPoolExecutor] = None,
+            max_workers: Optional[int] = None,
+            **kwargs
     ):
         """
         :param thread_pool: thread pool to be used

--- a/b2sdk/v0/__init__.py
+++ b/b2sdk/v0/__init__.py
@@ -9,7 +9,12 @@
 ######################################################################
 
 from b2sdk.v1 import *  # noqa
-from b2sdk.v0.account_info import AbstractAccountInfo, InMemoryAccountInfo, UrlPoolAccountInfo, SqliteAccountInfo
+from b2sdk.v0.account_info import (
+    AbstractAccountInfo,
+    InMemoryAccountInfo,
+    UrlPoolAccountInfo,
+    SqliteAccountInfo,
+)
 from b2sdk.v0.api import B2Api
 from b2sdk.v0.bucket import Bucket
 from b2sdk.v0.bucket import BucketFactory

--- a/b2sdk/v0/account_info.py
+++ b/b2sdk/v0/account_info.py
@@ -33,17 +33,17 @@ class OldAccountInfoMethods:
         None,
     )
     def set_auth_data(
-        self,
-        account_id,
-        auth_token,
-        api_url,
-        download_url,
-        minimum_part_size,
-        application_key,
-        realm,
-        allowed=None,
-        application_key_id=None,
-        s3_api_url=None,
+            self,
+            account_id,
+            auth_token,
+            api_url,
+            download_url,
+            minimum_part_size,
+            application_key,
+            realm,
+            allowed=None,
+            application_key_id=None,
+            s3_api_url=None,
     ):
         # we need to enumerate all the parameters and cannot just "*args, **kwargs" because
         # the deprecation decorator doesn't feel safe with the kwargs approach

--- a/b2sdk/v0/api.py
+++ b/b2sdk/v0/api.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from .bucket import Bucket, BucketFactory
+from .bucket import (
+    Bucket,
+    BucketFactory,
+)
 from b2sdk import v1
 
 

--- a/b2sdk/v0/bucket.py
+++ b/b2sdk/v0/bucket.py
@@ -19,7 +19,7 @@ class Bucket(v1.Bucket):
         return self.api.session.list_file_names(self.id_, start_filename, max_entries, prefix)
 
     def list_file_versions(
-        self, start_filename=None, start_file_id=None, max_entries=None, prefix=None
+            self, start_filename=None, start_file_id=None, max_entries=None, prefix=None
     ):
         """
         Legacy interface which just returns whatever remote API returns.

--- a/b2sdk/v0/sync.py
+++ b/b2sdk/v0/sync.py
@@ -14,13 +14,22 @@ from b2sdk.v1.exception import CommandError
 from b2sdk.v1.exception import DestFileNewer as DestFileNewerV1
 from b2sdk.v1 import trace_call
 from .exception import DestFileNewer
-from b2sdk.v1.exception import InvalidArgument, IncompleteSync
-from b2sdk.v1 import NewerFileSyncMode, CompareVersionMode
+from b2sdk.v1.exception import (
+    InvalidArgument,
+    IncompleteSync,
+)
+from b2sdk.v1 import (
+    NewerFileSyncMode,
+    CompareVersionMode,
+)
 from b2sdk.v1 import KeepOrDeleteMode
 from b2sdk.v1 import DEFAULT_SCAN_MANAGER
 from b2sdk.v1 import SyncReport
 from b2sdk.v1 import Synchronizer as SynchronizerV1
-from b2sdk.v1 import AbstractSyncEncryptionSettingsProvider, SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER
+from b2sdk.v1 import (
+    AbstractSyncEncryptionSettingsProvider,
+    SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,11 +62,11 @@ class Synchronizer(SynchronizerV1):
 
 
 def get_synchronizer_from_args(
-    args,
-    max_workers,
-    policies_manager=DEFAULT_SCAN_MANAGER,
-    dry_run=False,
-    allow_empty_source=False,
+        args,
+        max_workers,
+        policies_manager=DEFAULT_SCAN_MANAGER,
+        dry_run=False,
+        allow_empty_source=False,
 ):
     if args.replaceNewer and args.skipNewer:
         raise CommandError('--skipNewer and --replaceNewer are incompatible')
@@ -107,14 +116,14 @@ def get_synchronizer_from_args(
 
 
 def make_folder_sync_actions(
-    source_folder,
-    dest_folder,
-    args,
-    now_millis,
-    reporter,
-    policies_manager=DEFAULT_SCAN_MANAGER,
-    encryption_settings_provider:
-    AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+        source_folder,
+        dest_folder,
+        args,
+        now_millis,
+        reporter,
+        policies_manager=DEFAULT_SCAN_MANAGER,
+        encryption_settings_provider:
+        AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
 ):
     """
     This is deprecated. Use the new Synchronizer class.
@@ -155,18 +164,18 @@ def make_folder_sync_actions(
 
 @trace_call(logger)
 def sync_folders(
-    source_folder,
-    dest_folder,
-    args,
-    now_millis,
-    stdout,
-    no_progress,
-    max_workers,
-    policies_manager=DEFAULT_SCAN_MANAGER,
-    dry_run=False,
-    allow_empty_source=False,
-    encryption_settings_provider:
-    AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+        source_folder,
+        dest_folder,
+        args,
+        now_millis,
+        stdout,
+        no_progress,
+        max_workers,
+        policies_manager=DEFAULT_SCAN_MANAGER,
+        dry_run=False,
+        allow_empty_source=False,
+        encryption_settings_provider:
+        AbstractSyncEncryptionSettingsProvider = SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
 ):
     """
     This is deprecated. Use the new Synchronizer class.

--- a/b2sdk/v1/__init__.py
+++ b/b2sdk/v1/__init__.py
@@ -10,24 +10,47 @@
 
 from b2sdk.v2 import *  # noqa
 from b2sdk.v1.account_info import (
-    AbstractAccountInfo, InMemoryAccountInfo, UrlPoolAccountInfo, SqliteAccountInfo, StubAccountInfo
+    AbstractAccountInfo,
+    InMemoryAccountInfo,
+    UrlPoolAccountInfo,
+    SqliteAccountInfo,
+    StubAccountInfo,
 )
 from b2sdk.v1.api import B2Api
 from b2sdk.v1.b2http import B2Http
-from b2sdk.v1.bucket import Bucket, BucketFactory
+from b2sdk.v1.bucket import (
+    Bucket,
+    BucketFactory,
+)
 from b2sdk.v1.cache import AbstractCache
 from b2sdk.v1.download_dest import (
-    AbstractDownloadDestination, DownloadDestLocalFile, PreSeekedDownloadDest, DownloadDestBytes,
-    DownloadDestProgressWrapper
+    AbstractDownloadDestination,
+    DownloadDestLocalFile,
+    PreSeekedDownloadDest,
+    DownloadDestBytes,
+    DownloadDestProgressWrapper,
 )
-from b2sdk.v1.exception import CommandError, DestFileNewer
+from b2sdk.v1.exception import (
+    CommandError,
+    DestFileNewer,
+)
 from b2sdk.v1.file_metadata import FileMetadata
 from b2sdk.v1.file_version import FileVersionInfo
 from b2sdk.v1.session import B2Session
 from b2sdk.v1.sync import (
-    ScanPoliciesManager, DEFAULT_SCAN_MANAGER, zip_folders, Synchronizer, AbstractFolder,
-    LocalFolder, B2Folder, parse_sync_folder, SyncReport, File, B2File, FileVersion,
-    AbstractSyncEncryptionSettingsProvider
+    ScanPoliciesManager,
+    DEFAULT_SCAN_MANAGER,
+    zip_folders,
+    Synchronizer,
+    AbstractFolder,
+    LocalFolder,
+    B2Folder,
+    parse_sync_folder,
+    SyncReport,
+    File,
+    B2File,
+    FileVersion,
+    AbstractSyncEncryptionSettingsProvider,
 )
 from b2sdk.v1.replication.monitoring import ReplicationMonitor
 

--- a/b2sdk/v1/account_info.py
+++ b/b2sdk/v1/account_info.py
@@ -36,17 +36,17 @@ class OldAccountInfoMethods:
         ]
     )
     def set_auth_data(
-        self,
-        account_id,
-        auth_token,
-        api_url,
-        download_url,
-        minimum_part_size,
-        application_key,
-        realm,
-        allowed=None,
-        application_key_id=None,
-        s3_api_url=None,
+            self,
+            account_id,
+            auth_token,
+            api_url,
+            download_url,
+            minimum_part_size,
+            application_key,
+            realm,
+            allowed=None,
+            application_key_id=None,
+            s3_api_url=None,
     ):
 
         if 's3_api_url' in inspect.getfullargspec(self._set_auth_data).args:
@@ -74,17 +74,17 @@ class OldAccountInfoMethods:
 # translate legacy "minimum_part_size" to new style "recommended_part_size"
 class MinimumPartSizeTranslator:
     def _set_auth_data(
-        self,
-        account_id,
-        auth_token,
-        api_url,
-        download_url,
-        minimum_part_size,
-        application_key,
-        realm,
-        s3_api_url=None,
-        allowed=None,
-        application_key_id=None
+            self,
+            account_id,
+            auth_token,
+            api_url,
+            download_url,
+            minimum_part_size,
+            application_key,
+            realm,
+            s3_api_url=None,
+            allowed=None,
+            application_key_id=None
     ):
         if 's3_api_url' in inspect.getfullargspec(super()._set_auth_data).args:
             s3_kwargs = dict(s3_api_url=s3_api_url)
@@ -153,8 +153,8 @@ class AbstractAccountInfo(OldAccountInfoMethods, v2.AbstractAccountInfo):
 
     @abstractmethod
     def _set_auth_data(
-        self, account_id, auth_token, api_url, download_url, minimum_part_size, application_key,
-        realm, s3_api_url, allowed, application_key_id
+            self, account_id, auth_token, api_url, download_url, minimum_part_size, application_key,
+            realm, s3_api_url, allowed, application_key_id
     ):
         """
         Actually store the auth data.  Can assume that 'allowed' is present and valid.
@@ -189,4 +189,6 @@ class SqliteAccountInfo(MinimumPartSizeTranslator, OldAccountInfoMethods, v2.Sql
 
 
 class StubAccountInfo(MinimumPartSizeTranslator, OldAccountInfoMethods, v2.StubAccountInfo):
-    REALM_URLS = {'production': 'http://production.example.com'}
+    REALM_URLS = {
+        'production': 'http://production.example.com'
+    }

--- a/b2sdk/v1/api.py
+++ b/b2sdk/v1/api.py
@@ -8,15 +8,30 @@
 #
 ######################################################################
 
-from typing import Any, Dict, Optional, overload, Tuple, List
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    overload,
+    Tuple,
+    List,
+)
 
 from .download_dest import AbstractDownloadDestination
 from b2sdk import v2
 from b2sdk.api import Services
 from .account_info import AbstractAccountInfo
-from .bucket import Bucket, BucketFactory, download_file_and_return_info_dict
+from .bucket import (
+    Bucket,
+    BucketFactory,
+    download_file_and_return_info_dict,
+)
 from .cache import AbstractCache
-from .file_version import FileVersionInfo, FileVersionInfoFactory, file_version_info_from_id_and_name
+from .file_version import (
+    FileVersionInfo,
+    FileVersionInfoFactory,
+    file_version_info_from_id_and_name,
+)
 from .session import B2Session
 
 
@@ -35,13 +50,13 @@ class B2Api(v2.B2Api):
     FILE_VERSION_FACTORY_CLASS = staticmethod(FileVersionInfoFactory)
 
     def __init__(
-        self,
-        account_info: Optional[AbstractAccountInfo] = None,
-        cache: Optional[AbstractCache] = None,
-        raw_api: v2.B2RawHTTPApi = None,
-        max_upload_workers: int = 10,
-        max_copy_workers: int = 10,
-        api_config: Optional[v2.B2HttpApiConfig] = None,
+            self,
+            account_info: Optional[AbstractAccountInfo] = None,
+            cache: Optional[AbstractCache] = None,
+            raw_api: v2.B2RawHTTPApi = None,
+            max_upload_workers: int = 10,
+            max_copy_workers: int = 10,
+            api_config: Optional[v2.B2HttpApiConfig] = None,
     ):
         """
         Initialize the API using the given account info.
@@ -107,32 +122,32 @@ class B2Api(v2.B2Api):
 
     @overload
     def download_file_by_id(
-        self,
-        file_id: str,
-        download_dest: AbstractDownloadDestination,
-        progress_listener: Optional[v2.AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[v2.EncryptionSetting] = None,
+            self,
+            file_id: str,
+            download_dest: AbstractDownloadDestination,
+            progress_listener: Optional[v2.AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[v2.EncryptionSetting] = None,
     ) -> dict:
         ...
 
     @overload
     def download_file_by_id(
-        self,
-        file_id: str,
-        progress_listener: Optional[v2.AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[v2.EncryptionSetting] = None,
+            self,
+            file_id: str,
+            progress_listener: Optional[v2.AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[v2.EncryptionSetting] = None,
     ) -> v2.DownloadedFile:
         ...
 
     def download_file_by_id(
-        self,
-        file_id: str,
-        download_dest: Optional[AbstractDownloadDestination] = None,
-        progress_listener: Optional[v2.AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[v2.EncryptionSetting] = None,
+            self,
+            file_id: str,
+            download_dest: Optional[AbstractDownloadDestination] = None,
+            progress_listener: Optional[v2.AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[v2.EncryptionSetting] = None,
     ):
         """
         Download a file with the given ID.
@@ -187,12 +202,12 @@ class B2Api(v2.B2Api):
         )
 
     def create_key(
-        self,
-        capabilities: List[str],
-        key_name: str,
-        valid_duration_seconds: Optional[int] = None,
-        bucket_id: Optional[str] = None,
-        name_prefix: Optional[str] = None,
+            self,
+            capabilities: List[str],
+            key_name: str,
+            valid_duration_seconds: Optional[int] = None,
+            bucket_id: Optional[str] = None,
+            name_prefix: Optional[str] = None,
     ):
         return super().create_key(
             capabilities=capabilities,

--- a/b2sdk/v1/bucket.py
+++ b/b2sdk/v1/bucket.py
@@ -9,11 +9,19 @@
 ######################################################################
 
 from contextlib import suppress
-from typing import Optional, overload, Tuple
+from typing import (
+    Optional,
+    overload,
+    Tuple,
+)
 
 from .download_dest import AbstractDownloadDestination
 from .file_metadata import FileMetadata
-from .file_version import FileVersionInfo, FileVersionInfoFactory, file_version_info_from_download_version
+from .file_version import (
+    FileVersionInfo,
+    FileVersionInfoFactory,
+    file_version_info_from_download_version,
+)
 from b2sdk import v2
 from b2sdk.utils import validate_b2_file_name
 
@@ -29,17 +37,17 @@ class Bucket(v2.Bucket):
     FILE_VERSION_FACTORY = staticmethod(FileVersionInfoFactory)
 
     def copy_file(
-        self,
-        file_id,
-        new_file_name,
-        bytes_range=None,
-        metadata_directive=None,
-        content_type=None,
-        file_info=None,
-        destination_encryption: Optional[v2.EncryptionSetting] = None,
-        source_encryption: Optional[v2.EncryptionSetting] = None,
-        file_retention: Optional[v2.FileRetentionSetting] = None,
-        legal_hold: Optional[v2.LegalHold] = None,
+            self,
+            file_id,
+            new_file_name,
+            bytes_range=None,
+            metadata_directive=None,
+            content_type=None,
+            file_info=None,
+            destination_encryption: Optional[v2.EncryptionSetting] = None,
+            source_encryption: Optional[v2.EncryptionSetting] = None,
+            file_retention: Optional[v2.FileRetentionSetting] = None,
+            legal_hold: Optional[v2.LegalHold] = None,
     ):
         """
         Creates a new file in this bucket by (server-side) copying from an existing file.
@@ -72,12 +80,12 @@ class Bucket(v2.Bucket):
         )
 
     def start_large_file(
-        self,
-        file_name,
-        content_type=None,
-        file_info=None,
-        file_retention: Optional[v2.FileRetentionSetting] = None,
-        legal_hold: Optional[v2.LegalHold] = None,
+            self,
+            file_name,
+            content_type=None,
+            file_info=None,
+            file_retention: Optional[v2.FileRetentionSetting] = None,
+            legal_hold: Optional[v2.LegalHold] = None,
     ):
         """
         Start a large file transfer.
@@ -99,12 +107,12 @@ class Bucket(v2.Bucket):
         )
 
     def download_file_by_name(
-        self,
-        file_name: str,
-        download_dest: AbstractDownloadDestination,
-        progress_listener: Optional[v2.AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[v2.EncryptionSetting] = None,
+            self,
+            file_name: str,
+            download_dest: AbstractDownloadDestination,
+            progress_listener: Optional[v2.AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[v2.EncryptionSetting] = None,
     ):
         """
         Download a file by name.
@@ -138,32 +146,32 @@ class Bucket(v2.Bucket):
 
     @overload
     def download_file_by_id(
-        self,
-        file_id: str,
-        download_dest: AbstractDownloadDestination = None,
-        progress_listener: Optional[v2.AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[v2.EncryptionSetting] = None,
+            self,
+            file_id: str,
+            download_dest: AbstractDownloadDestination = None,
+            progress_listener: Optional[v2.AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[v2.EncryptionSetting] = None,
     ) -> dict:
         ...
 
     @overload
     def download_file_by_id(
-        self,
-        file_id: str,
-        progress_listener: Optional[v2.AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[v2.EncryptionSetting] = None,
+            self,
+            file_id: str,
+            progress_listener: Optional[v2.AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[v2.EncryptionSetting] = None,
     ) -> v2.DownloadedFile:
         ...
 
     def download_file_by_id(
-        self,
-        file_id: str,
-        download_dest: Optional[AbstractDownloadDestination] = None,
-        progress_listener: Optional[v2.AbstractProgressListener] = None,
-        range_: Optional[Tuple[int, int]] = None,
-        encryption: Optional[v2.EncryptionSetting] = None,
+            self,
+            file_id: str,
+            download_dest: Optional[AbstractDownloadDestination] = None,
+            progress_listener: Optional[v2.AbstractProgressListener] = None,
+            range_: Optional[Tuple[int, int]] = None,
+            encryption: Optional[v2.EncryptionSetting] = None,
     ):
         """
         Download a file by ID.
@@ -201,16 +209,16 @@ class Bucket(v2.Bucket):
         return self.api.file_version_factory.from_api_response(self.api.get_file_info(file_id))
 
     def update(
-        self,
-        bucket_type: Optional[str] = None,
-        bucket_info: Optional[dict] = None,
-        cors_rules: Optional[dict] = None,
-        lifecycle_rules: Optional[list] = None,
-        if_revision_is: Optional[int] = None,
-        default_server_side_encryption: Optional[v2.EncryptionSetting] = None,
-        default_retention: Optional[v2.BucketRetentionSetting] = None,
-        is_file_lock_enabled: Optional[bool] = None,
-        **kwargs
+            self,
+            bucket_type: Optional[str] = None,
+            bucket_info: Optional[dict] = None,
+            cors_rules: Optional[dict] = None,
+            lifecycle_rules: Optional[list] = None,
+            if_revision_is: Optional[int] = None,
+            default_server_side_encryption: Optional[v2.EncryptionSetting] = None,
+            default_retention: Optional[v2.BucketRetentionSetting] = None,
+            is_file_lock_enabled: Optional[bool] = None,
+            **kwargs
     ):
         """
         Update various bucket parameters.
@@ -246,11 +254,11 @@ class Bucket(v2.Bucket):
         )
 
     def ls(
-        self,
-        folder_to_list: str = '',
-        show_versions: bool = False,
-        recursive: bool = False,
-        fetch_count: Optional[int] = 10000
+            self,
+            folder_to_list: str = '',
+            show_versions: bool = False,
+            recursive: bool = False,
+            fetch_count: Optional[int] = 10000
     ):
         """
         Pretend that folders exist and yields the information about the files in a folder.
@@ -279,18 +287,18 @@ class Bucket(v2.Bucket):
 
 
 def download_file_and_return_info_dict(
-    downloaded_file: v2.DownloadedFile, download_dest: AbstractDownloadDestination,
-    range_: Optional[Tuple[int, int]]
+        downloaded_file: v2.DownloadedFile, download_dest: AbstractDownloadDestination,
+        range_: Optional[Tuple[int, int]]
 ):
     with download_dest.make_file_context(
-        file_id=downloaded_file.download_version.id_,
-        file_name=downloaded_file.download_version.file_name,
-        content_length=downloaded_file.download_version.size,
-        content_type=downloaded_file.download_version.content_type,
-        content_sha1=downloaded_file.download_version.content_sha1,
-        file_info=downloaded_file.download_version.file_info,
-        mod_time_millis=downloaded_file.download_version.mod_time_millis,
-        range_=range_,
+            file_id=downloaded_file.download_version.id_,
+            file_name=downloaded_file.download_version.file_name,
+            content_length=downloaded_file.download_version.size,
+            content_type=downloaded_file.download_version.content_type,
+            content_sha1=downloaded_file.download_version.content_sha1,
+            file_info=downloaded_file.download_version.file_info,
+            mod_time_millis=downloaded_file.download_version.mod_time_millis,
+            range_=range_,
     ) as file:
         downloaded_file.save(file)
         return FileMetadata.from_download_version(downloaded_file.download_version).as_info_dict()

--- a/b2sdk/v1/download_dest.py
+++ b/b2sdk/v1/download_dest.py
@@ -15,7 +15,11 @@ from contextlib import contextmanager
 
 from b2sdk.stream.progress import WritingStreamWithProgress
 
-from ..utils import B2TraceMetaAbstract, limit_trace_arguments, set_file_mtime
+from ..utils import (
+    B2TraceMetaAbstract,
+    limit_trace_arguments,
+    set_file_mtime,
+)
 
 
 class AbstractDownloadDestination(metaclass=B2TraceMetaAbstract):
@@ -28,15 +32,15 @@ class AbstractDownloadDestination(metaclass=B2TraceMetaAbstract):
         'content_sha1',
     ])
     def make_file_context(
-        self,
-        file_id,
-        file_name,
-        content_length,
-        content_type,
-        content_sha1,
-        file_info,
-        mod_time_millis,
-        range_=None
+            self,
+            file_id,
+            file_name,
+            content_length,
+            content_type,
+            content_sha1,
+            file_info,
+            mod_time_millis,
+            range_=None
     ):
         """
         Return a context manager that yields a binary file-like object to use for
@@ -65,15 +69,15 @@ class DownloadDestLocalFile(AbstractDownloadDestination):
         self.local_file_path = local_file_path
 
     def make_file_context(
-        self,
-        file_id,
-        file_name,
-        content_length,
-        content_type,
-        content_sha1,
-        file_info,
-        mod_time_millis,
-        range_=None
+            self,
+            file_id,
+            file_name,
+            content_length,
+            content_type,
+            content_sha1,
+            file_info,
+            mod_time_millis,
+            range_=None
     ):
         self.file_id = file_id
         self.file_name = file_name
@@ -137,15 +141,15 @@ class DownloadDestBytes(AbstractDownloadDestination):
         self.bytes_written = None
 
     def make_file_context(
-        self,
-        file_id,
-        file_name,
-        content_length,
-        content_type,
-        content_sha1,
-        file_info,
-        mod_time_millis,
-        range_=None
+            self,
+            file_id,
+            file_name,
+            content_length,
+            content_type,
+            content_sha1,
+            file_info,
+            mod_time_millis,
+            range_=None
     ):
         self.file_id = file_id
         self.file_name = file_name
@@ -189,15 +193,15 @@ class DownloadDestProgressWrapper(AbstractDownloadDestination):
         self.progress_listener = progress_listener
 
     def make_file_context(
-        self,
-        file_id,
-        file_name,
-        content_length,
-        content_type,
-        content_sha1,
-        file_info,
-        mod_time_millis,
-        range_=None
+            self,
+            file_id,
+            file_name,
+            content_length,
+            content_type,
+            content_sha1,
+            file_info,
+            mod_time_millis,
+            range_=None
     ):
         return self.write_file_and_report_progress_context(
             file_id, file_name, content_length, content_type, content_sha1, file_info,
@@ -206,12 +210,12 @@ class DownloadDestProgressWrapper(AbstractDownloadDestination):
 
     @contextmanager
     def write_file_and_report_progress_context(
-        self, file_id, file_name, content_length, content_type, content_sha1, file_info,
-        mod_time_millis, range_
+            self, file_id, file_name, content_length, content_type, content_sha1, file_info,
+            mod_time_millis, range_
     ):
         with self.download_dest.make_file_context(
-            file_id, file_name, content_length, content_type, content_sha1, file_info,
-            mod_time_millis, range_
+                file_id, file_name, content_length, content_type, content_sha1, file_info,
+                mod_time_millis, range_
         ) as file_:
             total_bytes = content_length
             if range_ is not None:

--- a/b2sdk/v1/exception.py
+++ b/b2sdk/v1/exception.py
@@ -9,6 +9,7 @@
 ######################################################################
 
 from b2sdk.v2.exception import *  # noqa
+
 v2DestFileNewer = DestFileNewer
 
 

--- a/b2sdk/v1/file_metadata.py
+++ b/b2sdk/v1/file_metadata.py
@@ -18,13 +18,13 @@ class FileMetadata:
     UNVERIFIED_CHECKSUM_PREFIX = 'unverified:'
 
     def __init__(
-        self,
-        file_id,
-        file_name,
-        content_type,
-        content_length,
-        content_sha1,
-        file_info,
+            self,
+            file_id,
+            file_name,
+            content_type,
+            content_length,
+            content_sha1,
+            file_info,
     ):
         self.file_id = file_id
         self.file_name = file_name

--- a/b2sdk/v1/file_version.py
+++ b/b2sdk/v1/file_version.py
@@ -27,23 +27,23 @@ class FileVersionInfo(v2.FileVersion):
     LS_ENTRY_TEMPLATE = '%83s  %6s  %10s  %8s  %9d  %s'  # order is file_id, action, date, time, size, name
 
     def __init__(
-        self,
-        id_,
-        file_name,
-        size,
-        content_type,
-        content_sha1,
-        file_info,
-        upload_timestamp,
-        action,
-        account_id: Optional[str] = None,
-        bucket_id: Optional[str] = None,
-        content_md5=None,
-        server_side_encryption: Optional[v2.EncryptionSetting] = None,
-        file_retention: Optional[v2.FileRetentionSetting] = None,
-        legal_hold: Optional[v2.LegalHold] = None,
-        api: Optional['v1api.B2Api'] = None,
-        **kwargs
+            self,
+            id_,
+            file_name,
+            size,
+            content_type,
+            content_sha1,
+            file_info,
+            upload_timestamp,
+            action,
+            account_id: Optional[str] = None,
+            bucket_id: Optional[str] = None,
+            content_md5=None,
+            server_side_encryption: Optional[v2.EncryptionSetting] = None,
+            file_retention: Optional[v2.FileRetentionSetting] = None,
+            legal_hold: Optional[v2.LegalHold] = None,
+            api: Optional['v1api.B2Api'] = None,
+            **kwargs
     ):
         self.id_ = id_
         self.file_name = file_name
@@ -147,7 +147,6 @@ class FileVersionInfoFactory(v2.FileVersionFactory):
     from_api_response = translate_single_file_version(v2.FileVersionFactory.from_api_response)
 
     def from_response_headers(self, headers):
-
         file_info = v2.DownloadVersionFactory.file_info_from_headers(headers)
         return FileVersionInfo(
             api=self.api,

--- a/b2sdk/v1/session.py
+++ b/b2sdk/v1/session.py
@@ -21,11 +21,11 @@ class B2Session(v2.B2Session):
     SQLITE_ACCOUNT_INFO_CLASS = staticmethod(SqliteAccountInfo)
 
     def __init__(
-        self,
-        account_info=None,
-        cache=None,
-        raw_api: v2.B2RawHTTPApi = None,
-        api_config: Optional[v2.B2HttpApiConfig] = None
+            self,
+            account_info=None,
+            cache=None,
+            raw_api: v2.B2RawHTTPApi = None,
+            api_config: Optional[v2.B2HttpApiConfig] = None
     ):
         if raw_api is not None and api_config is not None:
             raise InvalidArgument(

--- a/b2sdk/v1/sync/encryption_provider.py
+++ b/b2sdk/v1/sync/encryption_provider.py
@@ -29,11 +29,11 @@ class SyncEncryptionSettingsProviderWrapper(v2.AbstractSyncEncryptionSettingsPro
         )
 
     def get_setting_for_upload(
-        self,
-        bucket: Bucket,
-        b2_file_name: str,
-        file_info: Optional[dict],
-        length: int,
+            self,
+            bucket: Bucket,
+            b2_file_name: str,
+            file_info: Optional[dict],
+            length: int,
     ) -> Optional[v2.EncryptionSetting]:
         return self.provider.get_setting_for_upload(
             bucket=bucket,
@@ -43,20 +43,20 @@ class SyncEncryptionSettingsProviderWrapper(v2.AbstractSyncEncryptionSettingsPro
         )
 
     def get_source_setting_for_copy(
-        self,
-        bucket: Bucket,
-        source_file_version: v2.FileVersion,
+            self,
+            bucket: Bucket,
+            source_file_version: v2.FileVersion,
     ) -> Optional[v2.EncryptionSetting]:
         return self.provider.get_source_setting_for_copy(
             bucket=bucket, source_file_version_info=source_file_version
         )
 
     def get_destination_setting_for_copy(
-        self,
-        bucket: Bucket,
-        dest_b2_file_name: str,
-        source_file_version: v2.FileVersion,
-        target_file_info: Optional[dict] = None,
+            self,
+            bucket: Bucket,
+            dest_b2_file_name: str,
+            source_file_version: v2.FileVersion,
+            target_file_info: Optional[dict] = None,
     ) -> Optional[v2.EncryptionSetting]:
         return self.provider.get_destination_setting_for_copy(
             bucket=bucket,
@@ -66,9 +66,9 @@ class SyncEncryptionSettingsProviderWrapper(v2.AbstractSyncEncryptionSettingsPro
         )
 
     def get_setting_for_download(
-        self,
-        bucket: Bucket,
-        file_version: v2.FileVersion,
+            self,
+            bucket: Bucket,
+            file_version: v2.FileVersion,
     ) -> Optional[v2.EncryptionSetting]:
         return self.provider.get_setting_for_download(
             bucket=bucket,
@@ -86,11 +86,11 @@ def wrap_if_necessary(provider):
 class AbstractSyncEncryptionSettingsProvider(v2.AbstractSyncEncryptionSettingsProvider):
     @abstractmethod
     def get_setting_for_upload(
-        self,
-        bucket: Bucket,
-        b2_file_name: str,
-        file_info: Optional[dict],
-        length: int,
+            self,
+            bucket: Bucket,
+            b2_file_name: str,
+            file_info: Optional[dict],
+            length: int,
     ) -> Optional[v2.EncryptionSetting]:
         """
         Return an EncryptionSetting for uploading an object or None if server should decide.
@@ -98,9 +98,9 @@ class AbstractSyncEncryptionSettingsProvider(v2.AbstractSyncEncryptionSettingsPr
 
     @abstractmethod
     def get_source_setting_for_copy(
-        self,
-        bucket: Bucket,
-        source_file_version_info: FileVersionInfo,
+            self,
+            bucket: Bucket,
+            source_file_version_info: FileVersionInfo,
     ) -> Optional[v2.EncryptionSetting]:
         """
         Return an EncryptionSetting for a source of copying an object or None if not required
@@ -108,11 +108,11 @@ class AbstractSyncEncryptionSettingsProvider(v2.AbstractSyncEncryptionSettingsPr
 
     @abstractmethod
     def get_destination_setting_for_copy(
-        self,
-        bucket: Bucket,
-        dest_b2_file_name: str,
-        source_file_version_info: FileVersionInfo,
-        target_file_info: Optional[dict] = None,
+            self,
+            bucket: Bucket,
+            dest_b2_file_name: str,
+            source_file_version_info: FileVersionInfo,
+            target_file_info: Optional[dict] = None,
     ) -> Optional[v2.EncryptionSetting]:
         """
         Return an EncryptionSetting for a destination for copying an object or None if server should decide
@@ -120,9 +120,9 @@ class AbstractSyncEncryptionSettingsProvider(v2.AbstractSyncEncryptionSettingsPr
 
     @abstractmethod
     def get_setting_for_download(
-        self,
-        bucket: Bucket,
-        file_version_info: FileVersionInfo,
+            self,
+            bucket: Bucket,
+            file_version_info: FileVersionInfo,
     ) -> Optional[v2.EncryptionSetting]:
         """
         Return an EncryptionSetting for downloading an object from, or None if not required

--- a/b2sdk/v1/sync/file_to_path_translator.py
+++ b/b2sdk/v1/sync/file_to_path_translator.py
@@ -12,12 +12,17 @@ from typing import Tuple
 
 from b2sdk import v2
 
-from .file import B2File, B2FileVersion, File, FileVersion
+from .file import (
+    B2File,
+    B2FileVersion,
+    File,
+    FileVersion,
+)
 
 
 # The goal is to create v1.File objects together with v1.FileVersion objects from v2.SyncPath objects
 def make_files_from_paths(
-    dest_path: v2.AbstractSyncPath, source_path: v2.AbstractSyncPath, sync_type: str
+        dest_path: v2.AbstractSyncPath, source_path: v2.AbstractSyncPath, sync_type: str
 ) -> Tuple[File, File]:
     assert sync_type in ('b2-to-b2', 'b2-to-local', 'local-to-b2')
     sync_type_split = sync_type.split('-')
@@ -47,7 +52,10 @@ def _translate_local_path_to_file(path: v2.LocalSyncPath) -> File:
     return File(path.relative_path, [version])
 
 
-_path_translation_map = {'b2': _translate_b2_path_to_file, 'local': _translate_local_path_to_file}
+_path_translation_map = {
+    'b2': _translate_b2_path_to_file,
+    'local': _translate_local_path_to_file
+}
 
 
 # The goal is to create v2.SyncPath objects from v1.File objects
@@ -82,4 +90,7 @@ def _translate_local_file_to_path(file: File) -> v2.AbstractSyncPath:
     )
 
 
-_file_translation_map = {'b2': _translate_b2_file_to_path, 'local': _translate_local_file_to_path}
+_file_translation_map = {
+    'b2': _translate_b2_file_to_path,
+    'local': _translate_local_file_to_path
+}

--- a/b2sdk/v1/sync/folder.py
+++ b/b2sdk/v1/sync/folder.py
@@ -12,7 +12,10 @@ from abc import abstractmethod
 import functools
 
 from b2sdk import v2
-from .scan_policies import DEFAULT_SCAN_MANAGER, wrap_if_necessary
+from .scan_policies import (
+    DEFAULT_SCAN_MANAGER,
+    wrap_if_necessary,
+)
 from .. import exception
 
 
@@ -48,9 +51,9 @@ class B2Folder(v2.B2Folder, AbstractFolder):
 
     def get_file_versions(self):
         for file_version, _ in self.bucket.ls(
-            self.folder_name,
-            show_versions=True,
-            recursive=True,
+                self.folder_name,
+                show_versions=True,
+                recursive=True,
         ):
             yield file_version
 

--- a/b2sdk/v1/sync/folder_parser.py
+++ b/b2sdk/v1/sync/folder_parser.py
@@ -11,7 +11,10 @@
 from b2sdk import v2
 from .. import exception
 
-from .folder import LocalFolder, B2Folder
+from .folder import (
+    LocalFolder,
+    B2Folder,
+)
 
 
 # Override to use v1 version of "LocalFolder" and "B2Folder" and raise old style CommandError

--- a/b2sdk/v1/sync/scan_policies.py
+++ b/b2sdk/v1/sync/scan_policies.py
@@ -9,7 +9,11 @@
 ######################################################################
 
 import re
-from typing import Optional, Union, Iterable
+from typing import (
+    Optional,
+    Union,
+    Iterable,
+)
 
 from .file import B2FileVersion
 from ..file_version import FileVersionInfo
@@ -35,15 +39,15 @@ class ScanPoliciesManager(v2.ScanPoliciesManager):
     """
 
     def __init__(
-        self,
-        exclude_dir_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
-        exclude_file_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
-        include_file_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
-        exclude_all_symlinks: bool = False,
-        exclude_modified_before: Optional[int] = None,
-        exclude_modified_after: Optional[int] = None,
-        exclude_uploaded_before: Optional[int] = None,
-        exclude_uploaded_after: Optional[int] = None,
+            self,
+            exclude_dir_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
+            exclude_file_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
+            include_file_regexes: Iterable[Union[str, re.Pattern]] = tuple(),
+            exclude_all_symlinks: bool = False,
+            exclude_modified_before: Optional[int] = None,
+            exclude_modified_after: Optional[int] = None,
+            exclude_uploaded_before: Optional[int] = None,
+            exclude_uploaded_after: Optional[int] = None,
     ):
         """
         :param exclude_dir_regexes: regexes to exclude directories
@@ -78,7 +82,7 @@ class ScanPoliciesManager(v2.ScanPoliciesManager):
             exclude_modified_before, exclude_modified_after
         )
         with v2_exception.check_invalid_argument(
-            'exclude_uploaded_before,exclude_uploaded_after', '', ValueError
+                'exclude_uploaded_before,exclude_uploaded_after', '', ValueError
         ):
             self._include_upload_time_range = v2.IntegerRange(
                 exclude_uploaded_before, exclude_uploaded_after
@@ -138,7 +142,7 @@ class ScanPoliciesManagerWrapper(v2.ScanPoliciesManager):
 
     def should_exclude_local_path(self, local_path: v2.LocalSyncPath):
         if self.scan_policies_manager.should_exclude_file_version(
-            _translate_local_path_to_file(local_path).latest_version()
+                _translate_local_path_to_file(local_path).latest_version()
         ):
             return True
         return self.scan_policies_manager.should_exclude_file(local_path.relative_path)

--- a/b2sdk/v1/sync/sync.py
+++ b/b2sdk/v1/sync/sync.py
@@ -10,8 +10,14 @@
 
 from b2sdk import v2
 from b2sdk.v2 import exception as v2_exception
-from .file_to_path_translator import make_files_from_paths, make_paths_from_files
-from .scan_policies import DEFAULT_SCAN_MANAGER, wrap_if_necessary as scan_wrap_if_necessary
+from .file_to_path_translator import (
+    make_files_from_paths,
+    make_paths_from_files,
+)
+from .scan_policies import (
+    DEFAULT_SCAN_MANAGER,
+    wrap_if_necessary as scan_wrap_if_necessary,
+)
 from .encryption_provider import wrap_if_necessary as encryption_wrap_if_necessary
 from ..exception import DestFileNewer
 
@@ -27,17 +33,17 @@ def zip_folders(folder_a, folder_b, reporter, policies_manager=DEFAULT_SCAN_MANA
 # and to wrap encryption_settings_providers in argument name translators
 class Synchronizer(v2.Synchronizer):
     def __init__(
-        self,
-        max_workers,
-        policies_manager=DEFAULT_SCAN_MANAGER,
-        dry_run=False,
-        allow_empty_source=False,
-        newer_file_mode=v2.NewerFileSyncMode.RAISE_ERROR,
-        keep_days_or_delete=v2.KeepOrDeleteMode.NO_DELETE,
-        compare_version_mode=v2.CompareVersionMode.MODTIME,
-        compare_threshold=None,
-        keep_days=None,
-        sync_policy_manager: v2.SyncPolicyManager = v2.POLICY_MANAGER,
+            self,
+            max_workers,
+            policies_manager=DEFAULT_SCAN_MANAGER,
+            dry_run=False,
+            allow_empty_source=False,
+            newer_file_mode=v2.NewerFileSyncMode.RAISE_ERROR,
+            keep_days_or_delete=v2.KeepOrDeleteMode.NO_DELETE,
+            compare_version_mode=v2.CompareVersionMode.MODTIME,
+            compare_threshold=None,
+            keep_days=None,
+            sync_policy_manager: v2.SyncPolicyManager = v2.POLICY_MANAGER,
     ):
         super().__init__(
             max_workers,
@@ -53,13 +59,13 @@ class Synchronizer(v2.Synchronizer):
         )
 
     def make_folder_sync_actions(
-        self,
-        source_folder,
-        dest_folder,
-        now_millis,
-        reporter,
-        policies_manager=DEFAULT_SCAN_MANAGER,
-        encryption_settings_provider=v2.SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+            self,
+            source_folder,
+            dest_folder,
+            now_millis,
+            reporter,
+            policies_manager=DEFAULT_SCAN_MANAGER,
+            encryption_settings_provider=v2.SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
     ):
         return super()._make_folder_sync_actions(
             source_folder, dest_folder, now_millis, reporter,
@@ -69,15 +75,15 @@ class Synchronizer(v2.Synchronizer):
 
     # override to retain a public method
     def make_file_sync_actions(
-        self,
-        sync_type,
-        source_file,
-        dest_file,
-        source_folder,
-        dest_folder,
-        now_millis,
-        encryption_settings_provider: v2.AbstractSyncEncryptionSettingsProvider = v2.
-        SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+            self,
+            sync_type,
+            source_file,
+            dest_file,
+            source_folder,
+            dest_folder,
+            now_millis,
+            encryption_settings_provider: v2.AbstractSyncEncryptionSettingsProvider = v2.
+            SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
     ):
         """
         Yields the sequence of actions needed to sync the two files
@@ -103,15 +109,15 @@ class Synchronizer(v2.Synchronizer):
 
     # override to raise old style DestFileNewer exceptions
     def _make_file_sync_actions(
-        self,
-        sync_type,
-        source_path,
-        dest_path,
-        source_folder,
-        dest_folder,
-        now_millis,
-        encryption_settings_provider: v2.AbstractSyncEncryptionSettingsProvider = v2.
-        SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
+            self,
+            sync_type,
+            source_path,
+            dest_path,
+            source_folder,
+            dest_folder,
+            now_millis,
+            encryption_settings_provider: v2.AbstractSyncEncryptionSettingsProvider = v2.
+            SERVER_DEFAULT_SYNC_ENCRYPTION_SETTINGS_PROVIDER,
     ):
         """
         Yields the sequence of actions needed to sync the two files

--- a/b2sdk/v2/__init__.py
+++ b/b2sdk/v2/__init__.py
@@ -15,7 +15,13 @@ from b2sdk._v3 import LocalPath as LocalSyncPath
 
 from .api import B2Api
 from .b2http import B2Http
-from .bucket import Bucket, BucketFactory
+from .bucket import (
+    Bucket,
+    BucketFactory,
+)
 from .session import B2Session
 from .sync import B2SyncPath
-from .transfer import DownloadManager, UploadManager
+from .transfer import (
+    DownloadManager,
+    UploadManager,
+)

--- a/b2sdk/v2/api.py
+++ b/b2sdk/v2/api.py
@@ -10,10 +10,16 @@
 
 from b2sdk import _v3 as v3
 from b2sdk._v3.exception import BucketIdNotFound as v3BucketIdNotFound
-from .bucket import Bucket, BucketFactory
+from .bucket import (
+    Bucket,
+    BucketFactory,
+)
 from .exception import BucketIdNotFound
 from .session import B2Session
-from .transfer import DownloadManager, UploadManager
+from .transfer import (
+    DownloadManager,
+    UploadManager,
+)
 
 
 class Services(v3.Services):

--- a/b2sdk/v2/transfer.py
+++ b/b2sdk/v2/transfer.py
@@ -8,8 +8,14 @@
 #
 ######################################################################
 
-from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Callable, Optional
+from concurrent.futures import (
+    Future,
+    ThreadPoolExecutor,
+)
+from typing import (
+    Callable,
+    Optional,
+)
 
 from b2sdk import _v3 as v3
 

--- a/b2sdk/version_utils.py
+++ b/b2sdk/version_utils.py
@@ -8,7 +8,10 @@
 #
 ######################################################################
 
-from abc import ABCMeta, abstractmethod
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
 from functools import wraps
 import inspect
 import warnings


### PR DESCRIPTION
While a lot of changes are seen, most of them belong to one of these three categories:
1. from import chopped into tuple with a line per element (and an enforced trailing comma)
  - every time an import is added or removed, you can see a line appearing or disappearing from a file.
2. increased indent for function parameters in both calls and definitions
  - this way they stand a bit more, and it's easy to see that they're "something different" than the code around.
3. dictionaries chopped into a single element per line
  - the same motivation as with "from import" copping.