### PR TITLE
Exception message aligns with message expected of B2Cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Infrastructure
 * Additional tests for listing files/versions
+* Exception raised by authorized key for a single bucket with non-existing bucket now informs about bucket id
 
 ## [1.18.0] - 2022-09-20
 

--- a/b2sdk/api.py
+++ b/b2sdk/api.py
@@ -614,6 +614,6 @@ class B2Api(metaclass=B2TraceMeta):
         # If we have bucketId set we still need to check bucketName. If the bucketName is None,
         # it means that the bucketId belongs to a bucket that was already removed.
         if allowed_bucket_name is None:
-            raise RestrictedBucketMissing()
+            raise RestrictedBucketMissing(allowed_bucket_id)
 
         self.cache.save_bucket(self.BUCKET_CLASS(self, allowed_bucket_id, name=allowed_bucket_name))

--- a/b2sdk/exception.py
+++ b/b2sdk/exception.py
@@ -363,11 +363,12 @@ class RestrictedBucket(B2Error):
 
 
 class RestrictedBucketMissing(RestrictedBucket):
-    def __init__(self):
-        super().__init__('')
+    def __init__(self, bucket_id: int):
+        super().__init__(None)
+        self.bucket_id = bucket_id
 
     def __str__(self):
-        return 'Application key is restricted to a bucket that doesn\'t exist'
+        return "ERROR: application key is restricted to bucket id '%s', which no longer exists" % self.bucket_id
 
 
 class MaxFileSizeExceeded(B2Error):


### PR DESCRIPTION
Currently, the B2Cli tests depend on the specific message being generated when a bucket has ID but has no name. With exception being raised, another path is taken and literal message from the exception is being printed. This "fix" allows us to still use B2Cli tests without changes and modify them at our leisure. This also allows pipelines to pass (as B2Cli pipelines are using master branch from b2sdk).