### PR TITLE
CI/CD cleanup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ steps.build.outputs.version }}
-          body: ${{ steps.read-changelog.outputs.log_entry }}
+          body: ${{ steps.read-changelog.outputs.changes }}
           draft: false
           prerelease: false
           files: ${{ steps.build.outputs.asset_path }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,28 +27,20 @@ jobs:
         run: python -m pip install --upgrade nox pip setuptools
       - name: Build the distribution
         id: build
-        run: nox -vs build
+        run: nox -vs build >> $GITHUB_OUTPUT
       - name: Read the Changelog
         id: read-changelog
-        uses: mindsers/changelog-reader-action@v1
+        uses: mindsers/changelog-reader-action@v2
         with:
           version: ${{ steps.build.outputs.version }}
-      - name: Create GitHub release
-        id: create-release
-        uses: actions/create-release@v1
+      - name: Create GitHub release and upload the bundle
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.build.outputs.version }}
+          name: ${{ steps.build.outputs.version }}
           body: ${{ steps.read-changelog.outputs.log_entry }}
           draft: false
           prerelease: false
-      - name: Upload the distribution to GitHub
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ${{ steps.build.outputs.asset_path }}
-          asset_name: ${{ steps.build.outputs.asset_name }}
-          asset_content_type: application/gzip
+          files: ${{ steps.build.outputs.asset_path }}
       - name: Upload the distribution to PyPI
         if: ${{ env.B2_PYPI_PASSWORD != '' }}
         uses: pypa/gh-action-pypi-publish@v1.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,21 +58,20 @@ jobs:
       B2_TEST_APPLICATION_KEY_ID: ${{ secrets.B2_TEST_APPLICATION_KEY_ID }}
     runs-on: ubuntu-latest
     steps:
+      - name: Secrets validator
+        if: ${{ env.B2_TEST_APPLICATION_KEY == '' || env.B2_TEST_APPLICATION_KEY_ID == '' }}
+        run: echo "Empty B2_TEST_APPLICATION_KEY and/or B2_TEST_APPLICATION_KEY_ID" && exit 1
       - uses: actions/checkout@v3
-        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}  # TODO: skip this whole job instead
         with:
           fetch-depth: 0
       - name: Set up Python ${{ env.PYTHON_DEFAULT_VERSION }}
-        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}  # TODO: skip this whole job instead
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
           cache: "pip"
       - name: Install dependencies
-        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}  # TODO: skip this whole job instead
         run: python -m pip install --upgrade nox pip setuptools
       - name: Find and remove old buckets
-        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}  # TODO: skip this whole job instead
         run: nox -vs cleanup_old_buckets
   test:
     needs: cleanup_buckets
@@ -95,6 +94,9 @@ jobs:
           - os: "windows-latest"
             python-version: "pypy-3.8"
     steps:
+      - name: Secrets validator
+        if: ${{ env.B2_TEST_APPLICATION_KEY == '' || env.B2_TEST_APPLICATION_KEY_ID == '' }}
+        run: echo "Empty B2_TEST_APPLICATION_KEY and/or B2_TEST_APPLICATION_KEY_ID" && exit 1
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -110,7 +112,6 @@ jobs:
         env:
           SKIP_COVERAGE: ${{ startsWith(matrix.python-version, env.SKIP_COVERAGE_PYTHON_VERSION_PREFIX) }}
       - name: Run integration tests
-        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
         run: nox -vs integration -- --dont-cleanup-old-buckets
   doc:
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Additional tests for listing files/versions
 * Ensured that changelog validation only happens on pull requests
 * Upgraded GitHub actions checkout to v3, python-setup to v4
+* GitHub actions are using new GITHUB_OUTPUT instead of deprecated set-output
 
 ## [1.18.0] - 2022-09-20
 


### PR DESCRIPTION
- Using `GITHUB_OUTPUT` instead of deprecated `set-output`
- Single step secrets validator added to CI, replaces repeated conditions
- `nox -s build` inside CI prints only things for CI
- Using a maintained GitHub action for release creation and bundle upload

Example CD run: https://github.com/kkalinowski-reef/b2-sdk-python/actions/runs/3903420800
Example release: https://github.com/kkalinowski-reef/b2-sdk-python/releases/tag/v1.15.0
Example CI run: https://github.com/kkalinowski-reef/b2-sdk-python/actions/runs/3903094521
The only warning we're getting now is about macOS being 10.12 as the default soon.