### PR TITLE
fix repeated read on `UnboundSourceBytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Circular symlinks no longer cause infinite loops when syncing a folder
+* Fix crash on upload retry with unbound data source
 
 ### Infrastructure
 * Replaced `pyflakes` with `ruff` for linting

--- a/b2sdk/raw_simulator.py
+++ b/b2sdk/raw_simulator.py
@@ -1069,7 +1069,6 @@ class BucketSimulator:
         input_stream,
         server_side_encryption: Optional[EncryptionSetting] = None,
     ):
-        file_sim = self.file_id_to_file[file_id]
         part_data = self._simulate_chunked_post(input_stream, content_length)
         assert len(part_data) == content_length
         if sha1_sum == HEX_DIGITS_AT_END:
@@ -1079,8 +1078,11 @@ class BucketSimulator:
         computed_sha1 = hex_sha1_of_bytes(part_data)
         if sha1_sum != computed_sha1:
             raise PartSha1Mismatch(file_id)
+
+        file_sim = self.file_id_to_file[file_id]
         part = PartSimulator(file_sim.file_id, part_number, content_length, sha1_sum, part_data)
         file_sim.add_part(part_number, part)
+
         result = dict(
             fileId=file_id,
             partNumber=part_number,

--- a/b2sdk/transfer/emerge/planner/part_definition.py
+++ b/b2sdk/transfer/emerge/planner/part_definition.py
@@ -13,8 +13,12 @@ from functools import partial
 
 from b2sdk.stream.chained import ChainedStream
 from b2sdk.stream.range import wrap_with_range
+from typing import TYPE_CHECKING
 
 from b2sdk.utils import hex_sha1_of_unlimited_stream
+
+if TYPE_CHECKING:
+    from b2sdk.transfer.emerge.unbound_write_intent import UnboundSourceBytes
 
 
 class BaseEmergePartDefinition(metaclass=ABCMeta):
@@ -38,7 +42,7 @@ class BaseEmergePartDefinition(metaclass=ABCMeta):
 
 
 class UploadEmergePartDefinition(BaseEmergePartDefinition):
-    def __init__(self, upload_source, relative_offset, length):
+    def __init__(self, upload_source: "UnboundSourceBytes", relative_offset, length):
         self.upload_source = upload_source
         self.relative_offset = relative_offset
         self.length = length

--- a/b2sdk/transfer/outbound/upload_manager.py
+++ b/b2sdk/transfer/outbound/upload_manager.py
@@ -31,7 +31,7 @@ from ...utils.thread_pool import ThreadPoolMixin
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ...utils.typing import TypeUploadSource
+    from ...utils.typing import _TypeUploadSource
 
 
 class UploadManager(TransferManager, ThreadPoolMixin):
@@ -79,7 +79,7 @@ class UploadManager(TransferManager, ThreadPoolMixin):
         self,
         bucket_id,
         file_id,
-        part_upload_source: "TypeUploadSource",
+        part_upload_source: "_TypeUploadSource",
         part_number,
         large_file_upload_state,
         finished_parts=None,
@@ -101,7 +101,7 @@ class UploadManager(TransferManager, ThreadPoolMixin):
         self,
         bucket_id,
         file_id,
-        part_upload_source: "TypeUploadSource",
+        part_upload_source: "_TypeUploadSource",
         part_number,
         large_file_upload_state,
         finished_parts,

--- a/b2sdk/utils/typing.py
+++ b/b2sdk/utils/typing.py
@@ -12,4 +12,4 @@ from typing import TypeVar
 
 from b2sdk.transfer.outbound.upload_source import AbstractUploadSource
 
-TypeUploadSource = TypeVar("TypeUploadSource", bound=AbstractUploadSource)
+_TypeUploadSource = TypeVar("_TypeUploadSource", bound=AbstractUploadSource)

--- a/b2sdk/utils/typing.py
+++ b/b2sdk/utils/typing.py
@@ -1,0 +1,15 @@
+######################################################################
+#
+# File: b2sdk/utils/typing.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+from typing import TypeVar
+
+from b2sdk.transfer.outbound.upload_source import AbstractUploadSource
+
+TypeUploadSource = TypeVar("TypeUploadSource", bound=AbstractUploadSource)


### PR DESCRIPTION
- the actual fix is quite small - instead of attempting to go through a full lifecycle (opening/closing) of the stream with each retry, it's kept in scope without closing until the communication with API is concluded. Only after that the stream is closed via callback registered in the wrapping `ExitStack()`

- to reproduce the issue, copy-paste the test `test_upload_chunk_retry_stream_open` into the unpatched branch and run it. That should raise an unhandled exception.


- there are some unrelated changes with type annotations. They are not mandatory for the fix, but for someone who was diving into the codebase for the first time, it helped me to understand what I am looking at and navigate through the codebase easier way.


