### PR TITLE
Refactoring Large File Upload Continification Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Infrastructure
 * Replaced `pyflakes` with `ruff` for linting
-* Refactored logic for resuming large file uploads to unify code paths, correct inconsistencies, and enhance configurability (#381).
+* Refactored logic for resuming large file uploads to unify code paths, correct inconsistencies, and enhance configurability (#381)
 
 ## [1.21.0] - 2023-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Infrastructure
 * Replaced `pyflakes` with `ruff` for linting
+* Refactored logic for resuming large file uploads to unify code paths, correct inconsistencies, and enhance configurability (#381).
 
 ## [1.21.0] - 2023-04-17
 

--- a/b2sdk/transfer/emerge/executor.py
+++ b/b2sdk/transfer/emerge/executor.py
@@ -485,10 +485,9 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         :param cache_control: The cache control settings for the file, if any.
         
         :return: A tuple of the best matching unfinished file and its finished parts. If no match is found, it returns `None`.
-
-        Note: This operation requires the application key to have 'listFiles' access.
         """
-        assert 'plan_id' in file_info
+        if 'plan_id' not in file_info:
+            raise ValueError("The 'plan_id' key must be in file_info dictionary.")
 
         return self._find_matching_unfinished_file(
             bucket_id=bucket_id,
@@ -551,8 +550,6 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         :param cache_control: The cache control settings for the file, if set.
         
         :return: A tuple of the best matching unfinished file and its finished parts. If no match is found, returns `None`.
-
-        Note: This operation requires the application key to have 'listFiles' access.
         """
         logger.debug('Checking for matching unfinished large files for %s...', file_name)
 

--- a/b2sdk/transfer/emerge/executor.py
+++ b/b2sdk/transfer/emerge/executor.py
@@ -420,7 +420,7 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
                 emerge_part = emerge_parts_dict.get(part.part_number)
                 
                 if emerge_part is None:
-                    # somethign is wrong - we have a part that we don't know about
+                    # something is wrong - we have a part that we don't know about
                     # so we can't resume this upload
                     if log_rejections:
                         logger.debug('Rejecting %s: part %s not found in emerge parts, giving up.', file_.file_id, part.part_number)

--- a/b2sdk/transfer/emerge/executor.py
+++ b/b2sdk/transfer/emerge/executor.py
@@ -416,34 +416,41 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
             finished_parts = {}
 
             for part in self.services.large_file.list_parts(file_.file_id):
-                
+
                 emerge_part = emerge_parts_dict.get(part.part_number)
-                
+
                 if emerge_part is None:
                     # something is wrong - we have a part that we don't know about
                     # so we can't resume this upload
                     if log_rejections:
-                        logger.debug('Rejecting %s: part %s not found in emerge parts, giving up.', file_.file_id, part.part_number)
+                        logger.debug(
+                            'Rejecting %s: part %s not found in emerge parts, giving up.',
+                            file_.file_id, part.part_number
+                        )
                     finished_parts = None
                     break
-                
+
                 # Compare part sizes
                 if emerge_part.get_length() != part.content_length:
                     if log_rejections:
-                        logger.debug('Rejecting %s: part %s size mismatch', file_.file_id, part.part_number)
-                    continue # part size doesn't match - so we reupload
+                        logger.debug(
+                            'Rejecting %s: part %s size mismatch', file_.file_id, part.part_number
+                        )
+                    continue  # part size doesn't match - so we reupload
 
                 # Compare part hashes
                 if emerge_part.is_hashable() and emerge_part.get_sha1() != part.content_sha1:
                     if log_rejections:
-                        logger.debug('Rejecting %s: part %s sha1 mismatch', file_.file_id, part.part_number)
+                        logger.debug(
+                            'Rejecting %s: part %s sha1 mismatch', file_.file_id, part.part_number
+                        )
                     continue  # part.sha1 doesn't match - so we reupload
 
                 finished_parts[part.part_number] = part
 
             if finished_parts is None:
                 continue
-            
+
             finished_parts_len = len(finished_parts)
 
             if finished_parts and (

--- a/b2sdk/transfer/emerge/executor.py
+++ b/b2sdk/transfer/emerge/executor.py
@@ -327,6 +327,23 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         custom_upload_timestamp: Optional[int] = None,
         cache_control: Optional[str] = None,
     ):
+        """
+        Find an unfinished file upload matching a given plan ID and other parameters.
+
+        This function identifies unfinished file uploads that can be resumed. The target file is found by
+        matching the specified plan ID, along with other parameters such as encryption setting, file retention
+        setting, legal hold, custom upload timestamp, and cache control.
+
+        The function iterates through all the unfinished large file uploads. For each file, it validates if 
+        the file matches the provided parameters. If the file fails to match any parameter, it's excluded
+        from consideration.
+
+        If an unfinished file passes these checks, the function collects all the parts of the file that have
+        been uploaded so far. It then compares the number of finished parts of the current file with the
+        "best match" found so far. The best match is the file that has the most parts uploaded. 
+
+        The function finally returns the best match file and its finished parts. If no match is found, it returns None.
+        """
         file_retention = file_retention or NO_RETENTION_FILE_SETTING
         assert 'plan_id' in file_info
         best_match_file = None
@@ -405,11 +422,20 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         cache_control: Optional[str] = None,
     ):
         """
-        Find an unfinished file that may be used to resume a large file upload.  The
-        file is found using the filename and comparing the uploaded parts against
-        the local file.
+        Attempt to find an unfinished large file upload that can be resumed.
 
-        This is only possible if the application key being used allows ``listFiles`` access.
+        This function iterates through all unfinished large file uploads. For each file, 
+        it first checks if the file's name, file info, and other parameters match those given.
+        The parameters include the encryption setting, file retention setting, legal hold, 
+        custom upload timestamp, and cache control.
+
+        The function further validates if the parts of the unfinished file match the parts 
+        in the local file (emerge_parts_dict) based on the part size and SHA1 hash. 
+
+        If a file matches all these conditions, the function immediately returns that file 
+        and its finished parts. If no matching file is found, the function returns None. 
+
+        Note: This operation requires that the application key in use allows 'listFiles' access.
         """
         file_retention = file_retention or NO_RETENTION_FILE_SETTING
         file_info_without_large_file_sha1 = self._get_file_info_without_large_file_sha1(file_info)

--- a/b2sdk/transfer/emerge/executor.py
+++ b/b2sdk/transfer/emerge/executor.py
@@ -333,10 +333,6 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         """
         Search for a matching unfinished large file in the specified bucket.
 
-        This function is responsible for identifying a suitable unfinished file for resumption of upload,
-        based on the supplied parameters. It centralizes the shared logic between `_find_unfinished_file_by_plan_id`
-        and `_match_unfinished_file_if_possible`.
-
         In case a matching file is found but has inconsistencies (for example, mismatching file info or encryption settings),
         the 'log_rejections' parameter dictates if these mismatches should be logged.
 
@@ -364,6 +360,11 @@ class LargeFileEmergeExecution(BaseEmergeExecution):
         for file_ in self.services.large_file.list_unfinished_large_files(
             bucket_id, prefix=file_name
         ):
+            if file_.file_name != file_name:
+                if log_rejections:
+                    logger.debug('Rejecting %s: file name mismatch', file_.file_id)
+                continue
+
             if file_.file_info != file_info:
                 if check_file_info_without_large_file_sha1:
                     file_info_without_large_file_sha1 = self._get_file_info_without_large_file_sha1(


### PR DESCRIPTION
This PR addresses the issue #381, "Unify large file continuation preventors". The common logic from `_find_unfinished_file_by_plan_id` and `_match_unfinished_file_if_possible` is extracted into a new function named `_find_matching_unfinished_file`, which now handles their shared behavior. This new function includes three parameters, `log_rejections`, `check_file_info_without_large_file_sha1`, and `eager_mode`, to allow for flexible control over its behavior. Additionally, docstrings for all functions have been enhanced to better express their purpose and functionality.

Key changes and observations:

1. Most of the code between the two original functions was repetitive, except `_find_unfinished_file_by_plan_id` had significantly less logging.
2. The original handling of `None` encryption appeared inconsistent. Specifically, the way `None` encryption was handled seemed to vary, which was identified as a potential bug. In this refactor, we've standardized the handling of `None` encryption. The new condition for this is: `if encryption is not None and encryption != file_.encryption:`. This means that if encryption is not `None` and the encryption type does not match the file encryption, the condition will be true, leading to a more consistent and correct treatment of this edge case.
3. The original behavior for `sha1_sum` check was inconsistent. The new approach is less penalizing, re-uploading only the part with a mismatching `sha1`, similar to `_find_unfinished_file_by_plan_id`.
4. Previously, `_match_unfinished_file_if_possible` was checking `file_info_without_large_file_sha1`, while `_find_unfinished_file_by_plan_id` was not. In the refactored function `_find_matching_unfinished_file`, this check is now controlled by a parameter (`check_file_info_without_large_file_sha1`), giving us flexibility to handle this check based on the specific needs of the caller function.
5. The new function also checks for part size and part `sha`, previously only checked by `_match_unfinished_file_if_possible`. The updated approach reuploads parts with non-matching `sha` or size, rather than failing completely.
6. The original handling of `plan_id` logic was not explicit, and while it hasn't been changed in this PR, it is noted for potential future improvement.

Potential next steps (not addressed in this PR to maintain simplicity):

1. Make `plan_id` logic more explicit in the code.
2. Unify the approach to logging. Currently, the refactored functions have different approaches, which seems unnecessary.
3. Consider removing `_match_unfinished_file_if_possible` and `_find_unfinished_file_by_plan_id` entirely. They are only called in a single place in the code each, so perhaps we could replace these calls with calls to `_find_matching_unfinished_file`.