### PR TITLE
`ls` shell-like wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Added
-* Commands `ls` and `rm` now support shell-like patterns for wildcard matching beside of glob-like patterns.
+* Commands `ls` now supports shell-like patterns for wildcard matching beside of glob-like patterns.
 
 ## [1.23.0] - 2023-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,6 +483,7 @@ has changed.
 Initial official release of SDK as a separate package (until now it was a part of B2 CLI)
 
 [Unreleased]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.1...HEAD
+[1.23.0]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.1...v1.23.0
 [1.22.1]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/Backblaze/b2-sdk-python/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/Backblaze/b2-sdk-python/compare/v1.20.0...v1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+* Commands `ls` and `rm` now support shell-like patterns for wildcard matching beside of glob-like patterns.
+
 ## [1.23.0] - 2023-08-10
 
 ### Added
@@ -478,8 +482,7 @@ has changed.
 ### Added
 Initial official release of SDK as a separate package (until now it was a part of B2 CLI)
 
-[Unreleased]: https://github.com/Backblaze/b2-sdk-python/compare/v1.23.0...HEAD
-[1.23.0]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.1...v1.23.0
+[Unreleased]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.1...HEAD
 [1.22.1]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/Backblaze/b2-sdk-python/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/Backblaze/b2-sdk-python/compare/v1.20.0...v1.21.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,7 +482,7 @@ has changed.
 ### Added
 Initial official release of SDK as a separate package (until now it was a part of B2 CLI)
 
-[Unreleased]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.1...HEAD
+[Unreleased]: https://github.com/Backblaze/b2-sdk-python/compare/v1.23.0...HEAD
 [1.23.0]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.1...v1.23.0
 [1.22.1]: https://github.com/Backblaze/b2-sdk-python/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/Backblaze/b2-sdk-python/compare/v1.21.0...v1.22.0

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -384,11 +384,14 @@ class Bucket(metaclass=B2TraceMeta):
                 )
             else:
                 wc_flags = (
+                    wcglob.CASE |  # case sensitive
                     wcglob.BRACE |  # support {} for multiple options
-                    wcglob.GLOBSTAR  # support ** for recursive matching
+                    wcglob.GLOBSTAR |  # support ** for recursive matching
+                    wcglob.NEGATE  # support [!] for negation
                 )
                 wildcard_matcher = partial(
-                    lambda file_name: wcglob.globmatch(file_name, folder_to_list, flags=wc_flags)
+                    lambda file_name: wcglob.
+                    globmatch(file_name, folder_to_list, flags=wc_flags, limit=100)
                 )
 
         # Loop until all files in the named directory have been listed.

--- a/b2sdk/bucket.py
+++ b/b2sdk/bucket.py
@@ -53,7 +53,7 @@ from .utils import (
     limit_trace_arguments,
     validate_b2_file_name,
 )
-from .utils.fs import WildcardStyle, get_solid_prefix
+from .utils.wildcards import WildcardStyle, get_solid_prefix
 
 logger = logging.getLogger(__name__)
 

--- a/b2sdk/utils/fs.py
+++ b/b2sdk/utils/fs.py
@@ -34,6 +34,7 @@ def _find_unescaped_char(
             offset = starter_index + 1
             continue
         return starter_index
+    raise ValueError("no unescaped character found")
 
 
 def get_solid_prefix(
@@ -45,7 +46,7 @@ def get_solid_prefix(
     Examples:
        'b/c/*.txt' –> 'b/c/'
        '*.txt' –> ''
-       'a/*/result.[ct]sv' –> 'a/'
+       'a' –> 'a/'
     """
     MATCHERS = {
         # wildcard style: (wildcard match checker, allowed wildcard chars)
@@ -65,19 +66,20 @@ def get_solid_prefix(
     except KeyError:
         raise ValueError(f'Unknown wildcard style: {wildcard_style!r}')
 
-    wildcard_position = len(folder_to_list)
+    solid_length = len(folder_to_list)
     for wildcard_character in charset:
         try:
             char_index = finder(folder_to_list, wildcard_character)
         except ValueError:
             continue
         else:
-            wildcard_position = min(char_index, wildcard_position)
+            solid_length = min(char_index, solid_length)
 
     # +1 to include the starter character.  Using posix path to
     # ensure consistent behaviour on Windows (e.g. case sensitivity).
-    path = pathlib.PurePosixPath(folder_to_list[:wildcard_position + 1])
+    path = pathlib.PurePosixPath(folder_to_list[:solid_length + 1])
     parent_path = str(path.parent)
+
     # Path considers dot to be the empty path.
     # There's no shorter path than that.
     if parent_path == '.':

--- a/b2sdk/utils/fs.py
+++ b/b2sdk/utils/fs.py
@@ -7,6 +7,8 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+from __future__ import annotations
+
 import pathlib
 from enum import Enum
 

--- a/b2sdk/utils/fs.py
+++ b/b2sdk/utils/fs.py
@@ -1,0 +1,86 @@
+######################################################################
+#
+# File: b2sdk/utils/fs.py
+#
+# Copyright 2023 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+import pathlib
+from enum import Enum
+
+
+class WildcardStyle(str, Enum):
+    GLOB = 'glob'  # support * ? [], [!], no escaping
+    SHELL = 'shell'  # support *, **, ?, [], [!], {}, with escaping
+
+
+def _find_unescaped_char(
+    folder_to_list: str, wildcard_character: str, offset: int = 0
+) -> int | None:
+    """Find the first occurrence of a character in a string, ignoring escaped characters.
+    Raise ValueError if no unescaped character is found.
+    """
+    max_index = len(folder_to_list)
+    while offset < max_index:
+        starter_index = folder_to_list.index(wildcard_character, offset)
+        if starter_index is None:
+            return None
+        elif starter_index > 0 and folder_to_list[starter_index - 1] == '\\':
+            # the character is escaped, ignore it
+            offset = starter_index + 1
+            continue
+        return starter_index
+
+
+def get_solid_prefix(
+    current_prefix: str, folder_to_list: str, wildcard_style: WildcardStyle
+) -> str:
+    """If we're running with wildcard-matching, we could get a different prefix from it.
+    We search for the first occurrence of the special characters and fetch parent path from that place.
+
+    Examples:
+       'b/c/*.txt' –> 'b/c/'
+       '*.txt' –> ''
+       'a/*/result.[ct]sv' –> 'a/'
+    """
+    MATCHERS = {
+        # wildcard style: (wildcard match checker, allowed wildcard chars)
+        WildcardStyle.SHELL.value:
+            (
+                _find_unescaped_char,
+                ('*', '?', '[', '{'),  # ** is matched via *
+            ),
+        WildcardStyle.GLOB.value: (
+            lambda folder, char: folder.index(char),
+            ('*', '?', '['),
+        ),
+    }
+
+    try:
+        finder, charset = MATCHERS[wildcard_style]
+    except KeyError:
+        raise ValueError(f'Unknown wildcard style: {wildcard_style!r}')
+
+    wildcard_position = len(folder_to_list)
+    for wildcard_character in charset:
+        try:
+            char_index = finder(folder_to_list, wildcard_character)
+        except ValueError:
+            continue
+        else:
+            wildcard_position = min(char_index, wildcard_position)
+
+    # +1 to include the starter character.  Using posix path to
+    # ensure consistent behaviour on Windows (e.g. case sensitivity).
+    path = pathlib.PurePosixPath(folder_to_list[:wildcard_position + 1])
+    parent_path = str(path.parent)
+    # Path considers dot to be the empty path.
+    # There's no shorter path than that.
+    if parent_path == '.':
+        return ''
+
+    # We could receive paths in different stage, e.g. 'a/*/result.[ct]sv' has two
+    # possible parent paths: 'a/' and 'a/*/', with the first one being the correct one
+    return min(parent_path, current_prefix, key=len)

--- a/b2sdk/utils/wildcards.py
+++ b/b2sdk/utils/wildcards.py
@@ -27,7 +27,8 @@ def _find_unescaped_char(
     folder_to_list: str, wildcard_character: str, offset: int = 0
 ) -> int | None:
     """Find the first occurrence of a character in a string, ignoring escaped characters.
-    Raise ValueError if no unescaped character is found.
+
+    :raises ValueError: no unescaped character is found
     """
     max_index = len(folder_to_list)
     while offset < max_index:

--- a/b2sdk/utils/wildcards.py
+++ b/b2sdk/utils/wildcards.py
@@ -19,7 +19,7 @@ from wcmatch import glob as wcglob
 
 
 class WildcardStyle(str, Enum):
-    GLOB = 'glob'  # support * ? [], [!], no escaping
+    GLOB = 'glob'  # supports *, ? [], [!], no escaping
     SHELL = 'shell'  # support *, **, ?, [], [!], {}, with escaping
 
 

--- a/b2sdk/utils/wildcards.py
+++ b/b2sdk/utils/wildcards.py
@@ -20,7 +20,7 @@ from wcmatch import glob as wcglob
 
 class WildcardStyle(str, Enum):
     GLOB = 'glob'  # supports *, ? [], [!], no escaping
-    SHELL = 'shell'  # support *, **, ?, [], [!], {}, with escaping
+    SHELL = 'shell'  # supports *, **, ?, [], [!], {}, with escaping
 
 
 def _find_unescaped_char(

--- a/b2sdk/utils/wildcards.py
+++ b/b2sdk/utils/wildcards.py
@@ -1,6 +1,6 @@
 ######################################################################
 #
-# File: b2sdk/utils/fs.py
+# File: b2sdk/utils/wildcards.py
 #
 # Copyright 2023 Backblaze Inc. All Rights Reserved.
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ logfury>=1.0.1,<2.0.0
 requests>=2.9.1,<3.0.0
 tqdm>=4.5.0,<5.0.0
 typing-extensions>=4.7.1; python_version < '3.12'
-wcmatch~=8.4.1
+wcmatch>=8.4.1,<9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ logfury>=1.0.1,<2.0.0
 requests>=2.9.1,<3.0.0
 tqdm>=4.5.0,<5.0.0
 typing-extensions>=4.7.1; python_version < '3.12'
+wcmatch~=8.4.1

--- a/test/integration/fixtures/__init__.py
+++ b/test/integration/fixtures/__init__.py
@@ -9,8 +9,6 @@
 ######################################################################
 from __future__ import annotations
 
-import os
-
 import pytest
 from .. import get_b2_auth_data
 

--- a/test/integration/test_listing.py
+++ b/test/integration/test_listing.py
@@ -1,0 +1,132 @@
+######################################################################
+#
+# File: test/integration/test_listing.py
+#
+# Copyright 2021 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+from b2sdk.transfer.emerge.write_intent import WriteIntent
+from b2sdk.transfer.outbound.upload_source import UploadSourceBytes
+from b2sdk.utils.fs import WildcardStyle
+
+from .base import IntegrationTestBase
+from .fixtures import *  # pyflakes: disable
+
+
+class TestListing(IntegrationTestBase):
+    @pytest.fixture
+    def full_bucket(self):
+        bucket = self.create_bucket()
+        upload_source = UploadSourceBytes(b'hello world')
+        for path in ('a/z.txt', 'a/ba/z.txt', 'a/bb/z.txt', 'a/bc/z.txt', 'a/bd/cc/z.txt'):
+            bucket.create_file(
+                [WriteIntent(upload_source, destination_offset=0)], path, 'text/plain'
+            )
+        yield bucket
+
+    def test_listing_wildcard_shell(self, full_bucket):
+        for pattern, expected_result in (
+            (
+                'a/*.TXT',
+                set(),
+            ),
+            (
+                'a/\\*/z.txt',
+                set(),
+            ),
+            (
+                'a/*/z.txt',
+                {
+                    'a/ba/z.txt',
+                    'a/bb/z.txt',
+                    'a/bc/z.txt',
+                },
+            ),
+            (
+                'a/b[ab]/z.txt',
+                {
+                    'a/ba/z.txt',
+                    'a/bb/z.txt',
+                },
+            ),
+            (
+                'a/{ba,bb}/z.txt',
+                {
+                    'a/ba/z.txt',
+                    'a/bb/z.txt',
+                },
+            ),
+            (
+                'a/**/z.txt',
+                {
+                    'a/ba/z.txt',
+                    'a/bb/z.txt',
+                    'a/bc/z.txt',
+                    'a/bd/cc/z.txt',
+                    'a/z.txt',
+                },
+            ),
+            ('a/b[!b]/z.txt', {
+                'a/ba/z.txt',
+                'a/bc/z.txt',
+            }),
+        ):
+            res = full_bucket.ls(
+                folder_to_list=pattern,
+                recursive=True,
+                with_wildcard=True,
+                wildcard_style=WildcardStyle.SHELL,
+            )
+            assert {
+                item.file_name
+                for item, _ in res
+            } == expected_result, f"pattern {pattern} failed"
+
+    def test_listing_wildcard_glob(self, full_bucket):
+        for pattern, expected_result in (
+            (
+                'a/*/z.txt',
+                {
+                    'a/bd/cc/z.txt',
+                    'a/ba/z.txt',
+                    'a/bb/z.txt',
+                    'a/bc/z.txt',
+                },
+            ),
+            (
+                'a/b[ab]/z.txt',
+                {
+                    'a/ba/z.txt',
+                    'a/bb/z.txt',
+                },
+            ),
+            (
+                'a/**/z.txt',
+                {
+                    'a/ba/z.txt',
+                    'a/bb/z.txt',
+                    'a/bc/z.txt',
+                    'a/bd/cc/z.txt',
+                },
+            ),
+            ('a/b[!b]/z.txt', {
+                'a/ba/z.txt',
+                'a/bc/z.txt',
+            }),
+            (
+                'a/*.TXT',
+                set(),
+            ),
+        ):
+            res = full_bucket.ls(
+                folder_to_list=pattern,
+                recursive=True,
+                with_wildcard=True,
+                wildcard_style=WildcardStyle.GLOB,
+            )
+            assert {
+                item.file_name
+                for item, _ in res
+            } == expected_result, f"pattern {pattern} failed"

--- a/test/integration/test_listing.py
+++ b/test/integration/test_listing.py
@@ -9,7 +9,7 @@
 ######################################################################
 from b2sdk.transfer.emerge.write_intent import WriteIntent
 from b2sdk.transfer.outbound.upload_source import UploadSourceBytes
-from b2sdk.utils.fs import WildcardStyle
+from b2sdk.utils.wildcards import WildcardStyle
 
 from .base import IntegrationTestBase
 from .fixtures import *  # pyflakes: disable

--- a/test/integration/test_listing.py
+++ b/test/integration/test_listing.py
@@ -59,6 +59,14 @@ class TestListing(IntegrationTestBase):
                 },
             ),
             (
+                'a/b{a..c}/z.txt',
+                {
+                    'a/ba/z.txt',
+                    'a/bb/z.txt',
+                    'a/bc/z.txt',
+                },
+            ),
+            (
                 'a/**/z.txt',
                 {
                     'a/ba/z.txt',


### PR DESCRIPTION
Since the task is quite big, I split it into multiple PRs per command.

- accompanion PR in B2 CLI: https://github.com/reef-technologies/B2_Command_Line_Tool/pull/194/ (pipeline wont pass until this will get merged)


## Changes `ls`
- Allow `*`, `**`, `?` ,`[]` ,`{}` globs/patterns in `b2 ls`,  globbing should work similarly to bash globs. Allow escaping special symbols with backslash `\`.