### PR TITLE
Interface for description changing for active listeners

### DIFF
--- a/changelog.d/+progress-listener-can-have-description-changed.infrastructure.md
+++ b/changelog.d/+progress-listener-can-have-description-changed.infrastructure.md
@@ -1,0 +1,1 @@
+Progress listener instances can now change their descriptions during run. This allows for e.g.: changing description after file headers are downloaded but before the content is fetched.


### PR DESCRIPTION
In order to provide a "generated" filename to the progress bar during `DownloadFile.save_to`, we need to be able to change the description right after we receive headers but before we call the `save_to` method.

Because of that, description becomes part of the `AbstractProgressListener`, albeit optional. Two methods are exposed, one allowing to perform a change on the description and another checking whether the change can be performed. In case of both `tqdm` and `SimpleProgressListener` it is impossible to perform the change at any time.