### PR TITLE
Fix moved paths in docstrings

### DIFF
--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -344,7 +344,7 @@ class B2Folder(AbstractFolder):
         :param folder_name: a folder name
         :type folder_name: str
         :param api: an API object
-        :type api: b2sdk.api.B2Api
+        :type api: b2sdk._internal.api.B2Api
         """
         self.bucket_name = bucket_name
         self.folder_name = folder_name

--- a/b2sdk/_internal/scan/scan.py
+++ b/b2sdk/_internal/scan/scan.py
@@ -35,8 +35,8 @@ def zip_folders(
     in both folders.  Either file (but not both) will be None if the
     file is in only one folder.
 
-    :param b2sdk.scan.folder.AbstractFolder folder_a: first folder object.
-    :param b2sdk.scan.folder.AbstractFolder folder_b: second folder object.
+    :param b2sdk._internal.scan.folder.AbstractFolder folder_a: first folder object.
+    :param b2sdk._internal.scan.folder.AbstractFolder folder_b: second folder object.
     :param reporter: reporter object
     :param policies_manager: policies manager object
     :return: yields two element tuples

--- a/b2sdk/_internal/session.py
+++ b/b2sdk/_internal/session.py
@@ -61,11 +61,11 @@ class B2Session:
                       :class:`~b2sdk.v2.SqliteAccountInfo`
 
         :param cache: an instance of the one of the following classes:
-                      :class:`~b2sdk.cache.DummyCache`, :class:`~b2sdk.cache.InMemoryCache`,
-                      :class:`~b2sdk.cache.AuthInfoCache`,
-                      or any custom class derived from :class:`~b2sdk.cache.AbstractCache`
+                      :class:`~b2sdk._internal.cache.DummyCache`, :class:`~b2sdk._internal.cache.InMemoryCache`,
+                      :class:`~b2sdk._internal.cache.AuthInfoCache`,
+                      or any custom class derived from :class:`~b2sdk._internal.cache.AbstractCache`
                       It is used by B2Api to cache the mapping between bucket name and bucket ids.
-                      default is :class:`~b2sdk.cache.DummyCache`
+                      default is :class:`~b2sdk._internal.cache.DummyCache`
 
         :param api_config
         """

--- a/b2sdk/_internal/sync/action.py
+++ b/b2sdk/_internal/sync/action.py
@@ -45,7 +45,7 @@ class AbstractAction(metaclass=ABCMeta):
         Main action routine.
 
         :param bucket: a Bucket object
-        :type bucket: b2sdk.bucket.Bucket
+        :type bucket: b2sdk._internal.bucket.Bucket
         :param reporter: a place to report errors
         :param dry_run: if True, perform a dry run
         :type dry_run: bool

--- a/b2sdk/_internal/sync/sync.py
+++ b/b2sdk/_internal/sync/sync.py
@@ -37,7 +37,7 @@ def count_files(local_folder, reporter, policies_manager):
     """
     Count all of the files in a local folder.
 
-    :param b2sdk.scan.folder.AbstractFolder local_folder: a folder object.
+    :param b2sdk._internal.scan.folder.AbstractFolder local_folder: a folder object.
     :param reporter: reporter object
     """
     # Don't pass in a reporter to all_files.  Broken symlinks will be reported

--- a/b2sdk/_internal/transfer/emerge/emerger.py
+++ b/b2sdk/_internal/transfer/emerge/emerger.py
@@ -32,7 +32,7 @@ class Emerger(metaclass=B2TraceMetaAbstract):
 
     It creates a emerge plan and pass it to emerge executor - all complex logic
     is actually implemented in :class:`b2sdk._internal.transfer.emerge.planner.planner.EmergePlanner`
-    and :class:`b2sdk.transfer.emerge.executor.EmergeExecutor`
+    and :class:`b2sdk._internal.transfer.emerge.executor.EmergeExecutor`
     """
 
     DEFAULT_STREAMING_MAX_QUEUE_SIZE = 100

--- a/b2sdk/_internal/transfer/emerge/planner/planner.py
+++ b/b2sdk/_internal/transfer/emerge/planner/planner.py
@@ -349,7 +349,7 @@ class EmergePlanner:
     def _buff_split(self, upload_buffer):
         """ Split upload buffer to parts candidates - smaller upload buffers.
 
-        :rtype iterator[b2sdk.transfer.emerge.planner.planner.UploadBuffer]:
+        :rtype iterator[b2sdk._internal.transfer.emerge.planner.planner.UploadBuffer]:
         """
         if upload_buffer.intent_count() == 0:
             return
@@ -369,8 +369,8 @@ class EmergePlanner:
 
         In result left part cannot be split more, and nothing can be assumed about right part.
 
-        :rtype tuple(b2sdk.transfer.emerge.planner.planner.UploadBuffer,
-                     b2sdk.transfer.emerge.planner.planner.UploadBuffer):
+        :rtype tuple(b2sdk._internal.transfer.emerge.planner.planner.UploadBuffer,
+                     b2sdk._internal.transfer.emerge.planner.planner.UploadBuffer):
         """
         left_buff = UploadBuffer(upload_buffer.start_offset)
         buff_start = upload_buffer.start_offset

--- a/b2sdk/_internal/transfer/outbound/progress_reporter.py
+++ b/b2sdk/_internal/transfer/outbound/progress_reporter.py
@@ -15,17 +15,17 @@ from b2sdk._internal.progress import AbstractProgressListener
 class PartProgressReporter(AbstractProgressListener):
     """
     An adapter that listens to the progress of upload a part and
-    gives the information to a :py:class:`b2sdk.bucket.LargeFileUploadState`.
+    gives the information to a :py:class:`b2sdk._internal.transfer.outbound.large_file_upload_state.LargeFileUploadState`.
 
     Accepts absolute bytes_completed from the uploader, and reports
-    deltas to the :py:class:`b2sdk.bucket.LargeFileUploadState`.  The bytes_completed for the
+    deltas to the :py:class:`b2sdk._internal.transfer.outbound.large_file_upload_state.LargeFileUploadState`.  The bytes_completed for the
     part will drop back to 0 on a retry, which will result in a
     negative delta.
     """
 
     def __init__(self, large_file_upload_state, *args, **kwargs):
         """
-        :param b2sdk.bucket.LargeFileUploadState large_file_upload_state: object to relay the progress to
+        :param b2sdk._internal.transfer.outbound.large_file_upload_state.LargeFileUploadState large_file_upload_state: object to relay the progress to
         """
         super().__init__(*args, **kwargs)
         self.large_file_upload_state = large_file_upload_state

--- a/b2sdk/v0/sync.py
+++ b/b2sdk/v0/sync.py
@@ -122,9 +122,9 @@ def make_folder_sync_actions(
     folder to the source folder.
 
     :param source_folder: source folder object
-    :type source_folder: b2sdk.scan.folder.AbstractFolder
+    :type source_folder: b2sdk._internal.scan.folder.AbstractFolder
     :param dest_folder: destination folder object
-    :type dest_folder: b2sdk.scan.folder.AbstractFolder
+    :type dest_folder: b2sdk._internal.scan.folder.AbstractFolder
     :param args: an object which holds command line arguments
     :param now_millis: current time in milliseconds
     :type now_millis: int
@@ -175,9 +175,9 @@ def sync_folders(
     in the destination older than history_days.
 
     :param source_folder: source folder object
-    :type source_folder: b2sdk.scan.folder.AbstractFolder
+    :type source_folder: b2sdk._internal.scan.folder.AbstractFolder
     :param dest_folder: destination folder object
-    :type dest_folder: b2sdk.scan.folder.AbstractFolder
+    :type dest_folder: b2sdk._internal.scan.folder.AbstractFolder
     :param args: an object which holds command line arguments
     :param now_millis: current time in milliseconds
     :type now_millis: int

--- a/b2sdk/v1/api.py
+++ b/b2sdk/v1/api.py
@@ -51,7 +51,7 @@ class B2Api(v2.B2Api):
                       :class:`~b2sdk.v1.SqliteAccountInfo`
 
         :param cache: It is used by B2Api to cache the mapping between bucket name and bucket ids.
-                      default is :class:`~b2sdk.cache.DummyCache`
+                      default is :class:`~b2sdk._internal.cache.DummyCache`
 
         :param max_upload_workers: a number of upload threads
         :param max_copy_workers: a number of copy threads


### PR DESCRIPTION
There's some in the file `doc/markup-test.rst`, but IDK if we need to fix them.