### PR TITLE
Skip and report invalid filenames when syncing

### DIFF
--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -241,22 +241,15 @@ class LocalFolder(AbstractFolder):
 
             visited_symlinks.add(inode_number)
 
-        for name in (x.name for x in local_dir.iterdir()):
-
-            if '/' in name:
-                raise UnsupportedFilename(
-                    "scan does not support file names that include '/'",
-                    f"{name} in dir {local_dir}"
-                )
-
-            local_path = local_dir / name
+        for local_path in local_dir.iterdir():
+            name = local_path.name
             relative_file_path = join_b2_path(relative_dir_path, name)
 
             try:
                 validate_b2_file_name(name)
             except ValueError as e:
                 if reporter is not None:
-                    reporter.invalid_filename(str(local_path), str(e))
+                    reporter.invalid_name(str(local_path), str(e))
                 continue
 
             # Skip broken symlinks or other inaccessible files

--- a/b2sdk/_internal/scan/folder.py
+++ b/b2sdk/_internal/scan/folder.py
@@ -18,7 +18,7 @@ from abc import ABCMeta, abstractmethod
 from pathlib import Path
 from typing import Iterator
 
-from ..utils import fix_windows_path_limit, get_file_mtime, is_file_readable
+from ..utils import fix_windows_path_limit, get_file_mtime, is_file_readable, validate_b2_file_name
 from .exception import (
     EmptyDirectory,
     EnvironmentEncodingError,
@@ -251,6 +251,13 @@ class LocalFolder(AbstractFolder):
 
             local_path = local_dir / name
             relative_file_path = join_b2_path(relative_dir_path, name)
+
+            try:
+                validate_b2_file_name(name)
+            except ValueError as e:
+                if reporter is not None:
+                    reporter.invalid_filename(str(local_path), str(e))
+                continue
 
             # Skip broken symlinks or other inaccessible files
             if not is_file_readable(str(local_path), reporter):

--- a/b2sdk/_internal/scan/report.py
+++ b/b2sdk/_internal/scan/report.py
@@ -48,6 +48,7 @@ class ProgressReport:
         self._last_update_time = 0
         self._update_progress()
         self.warnings = []
+        self.errors_encountered = False
 
     def close(self):
         """
@@ -67,6 +68,14 @@ class ProgressReport:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    def has_errors_or_warnings(self) -> bool:
+        """
+        Check if there are any errors or warnings.
+
+        :return: True if there are any errors or warnings
+        """
+        return self.errors_encountered or bool(self.warnings)
+
     def error(self, message: str) -> None:
         """
         Print an error, gracefully interleaving it with a progress bar.
@@ -74,6 +83,7 @@ class ProgressReport:
         :param message: an error message
         """
         self.print_completion(message)
+        self.errors_encountered = True
 
     def print_completion(self, message: str) -> None:
         """

--- a/b2sdk/_internal/scan/report.py
+++ b/b2sdk/_internal/scan/report.py
@@ -202,13 +202,13 @@ class ProgressReport:
             f'WARNING: {path} is a circular symlink, which was already visited. Skipping.'
         )
 
-    def invalid_filename(self, path: str, error: str) -> None:
+    def invalid_name(self, path: str, error: str) -> None:
         """
         Add an invalid filename error message to the list of warnings.
 
         :param path: file path
         """
-        self.warnings.append(f'WARNING: {path} has an invalid filename ({error}). Skipping.')
+        self.warnings.append(f'WARNING: {path!r} path contains invalid name ({error}). Skipping.')
 
 
 def sample_report_run():

--- a/b2sdk/_internal/scan/report.py
+++ b/b2sdk/_internal/scan/report.py
@@ -191,6 +191,14 @@ class ProgressReport:
             f'WARNING: {path} is a circular symlink, which was already visited. Skipping.'
         )
 
+    def invalid_filename(self, path: str, error: str) -> None:
+        """
+        Add an invalid filename error message to the list of warnings.
+
+        :param path: file path
+        """
+        self.warnings.append(f'WARNING: {path} has an invalid filename ({error}). Skipping.')
+
 
 def sample_report_run():
     """

--- a/b2sdk/_internal/scan/report.py
+++ b/b2sdk/_internal/scan/report.py
@@ -54,11 +54,12 @@ class ProgressReport:
         Perform a clean-up.
         """
         with self.lock:
-            if not self.no_progress:
-                self._print_line('', False)
-            self.closed = True
-            for warning in self.warnings:
-                self._print_line(warning, True)
+            if not self.closed:
+                if not self.no_progress:
+                    self._print_line('', False)
+                for warning in self.warnings:
+                    self._print_line(warning, True)
+                self.closed = True
 
     def __enter__(self):
         return self

--- a/b2sdk/_internal/scan/report.py
+++ b/b2sdk/_internal/scan/report.py
@@ -55,12 +55,11 @@ class ProgressReport:
         Perform a clean-up.
         """
         with self.lock:
-            if not self.closed:
-                if not self.no_progress:
-                    self._print_line('', False)
-                for warning in self.warnings:
-                    self._print_line(warning, True)
-                self.closed = True
+            if not self.no_progress:
+                self._print_line('', False)
+            self.closed = True
+            for warning in self.warnings:
+                self._print_line(warning, True)
 
     def __enter__(self):
         return self

--- a/b2sdk/_internal/scan/report.py
+++ b/b2sdk/_internal/scan/report.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from io import TextIOWrapper
 
 from ..utils import format_and_scale_number
+from ..utils.escape import escape_control_chars
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +179,9 @@ class ProgressReport:
 
         :param path: file path
         """
-        self.warnings.append(f'WARNING: {path} could not be accessed (broken symlink?)')
+        self.warnings.append(
+            f'WARNING: {escape_control_chars(path)} could not be accessed (broken symlink?)'
+        )
 
     def local_permission_error(self, path: str) -> None:
         """
@@ -186,7 +189,9 @@ class ProgressReport:
 
         :param path: file path
         """
-        self.warnings.append(f'WARNING: {path} could not be accessed (no permissions to read?)')
+        self.warnings.append(
+            f'WARNING: {escape_control_chars(path)} could not be accessed (no permissions to read?)'
+        )
 
     def symlink_skipped(self, path: str) -> None:
         pass
@@ -198,7 +203,7 @@ class ProgressReport:
         :param path: file path
         """
         self.warnings.append(
-            f'WARNING: {path} is a circular symlink, which was already visited. Skipping.'
+            f'WARNING: {escape_control_chars(path)} is a circular symlink, which was already visited. Skipping.'
         )
 
     def invalid_name(self, path: str, error: str) -> None:
@@ -207,7 +212,9 @@ class ProgressReport:
 
         :param path: file path
         """
-        self.warnings.append(f'WARNING: {path!r} path contains invalid name ({error}). Skipping.')
+        self.warnings.append(
+            f'WARNING: {escape_control_chars(path)} path contains invalid name ({error}). Skipping.'
+        )
 
 
 def sample_report_run():

--- a/b2sdk/_internal/utils/__init__.py
+++ b/b2sdk/_internal/utils/__init__.py
@@ -230,7 +230,10 @@ def validate_b2_file_name(name):
     """
     if not isinstance(name, str):
         raise ValueError('file name must be a string, not bytes')
-    name_utf8 = name.encode('utf-8')
+    try:
+        name_utf8 = name.encode('utf-8')
+    except UnicodeEncodeError:
+        raise ValueError('file name must be valid Unicode, check locale')
     if len(name_utf8) < 1:
         raise ValueError('file name too short (0 utf-8 bytes)')
     if 1000 < len(name_utf8):

--- a/b2sdk/_internal/utils/escape.py
+++ b/b2sdk/_internal/utils/escape.py
@@ -8,6 +8,8 @@
 #
 ######################################################################
 
+from __future__ import annotations
+
 import re
 import shlex
 
@@ -15,44 +17,40 @@ import shlex
 UNPRINTABLE_PATTERN = re.compile(r'[\x00-\x08\x0e-\x1f\x7f-\x9f]')
 
 
-def unprintable_to_hex(s):
+def unprintable_to_hex(s: str) -> str:
     """
     Replace unprintable chars in string with a hex representation.
 
-    :param string: an arbitrary string, possibly with unprintable characters.
+    :param s: an arbitrary string, possibly with unprintable characters.
     :return: the string, with unprintable characters changed to hex (e.g., "\x07")
-
     """
 
     def hexify(match):
-        return fr'\x{ord(match.group()):02x}'
+        return rf"\x{ord(match.group()):02x}"
 
     if s:
         return UNPRINTABLE_PATTERN.sub(hexify, s)
-    return None
+    return s
 
 
-def escape_control_chars(s):
+def escape_control_chars(s: str) -> str:
     """
     Replace unprintable chars in string with a hex representation AND shell quotes the string.
 
-    :param string: an arbitrary string, possibly with unprintable characters.
+    :param s: an arbitrary string, possibly with unprintable characters.
     :return: the string, with unprintable characters changed to hex (e.g., "\x07")
-
     """
     if s:
         return shlex.quote(unprintable_to_hex(s))
-    return None
+    return s
 
 
-def substitute_control_chars(s):
+def substitute_control_chars(s: str) -> tuple[str, bool]:
     """
     Replace unprintable chars in string with � unicode char
 
-    :param string: an arbitrary string, possibly with unprintable characters.
+    :param s: an arbitrary string, possibly with unprintable characters.
     :return: tuple of the string with � replacements made and boolean indicated if chars were replaced
-
     """
-    match_result = UNPRINTABLE_PATTERN.search(s)
-    s = UNPRINTABLE_PATTERN.sub('�', s)
-    return (s, match_result is not None)
+    new_value = UNPRINTABLE_PATTERN.sub("�", s)
+    return new_value, new_value != s

--- a/changelog.d/+duplicate-warnings.fixed.md
+++ b/changelog.d/+duplicate-warnings.fixed.md
@@ -1,0 +1,1 @@
+Fix duplicate reporting of warnings.

--- a/changelog.d/+duplicate-warnings.fixed.md
+++ b/changelog.d/+duplicate-warnings.fixed.md
@@ -1,1 +1,0 @@
-Fix duplicate reporting of warnings.

--- a/changelog.d/+escape_funcs.fixed.md
+++ b/changelog.d/+escape_funcs.fixed.md
@@ -1,0 +1,1 @@
+Ensure `unprintable_to_hex` and `unprintable_to_hex` return empty string (instead of `None`) if empty string was supplied as argument.

--- a/changelog.d/+invalid-filename.fixed.md
+++ b/changelog.d/+invalid-filename.fixed.md
@@ -1,0 +1,1 @@
+Report and skip invalid filenames found when scanning directories (for `sync`, ...).

--- a/test/unit/scan/test_folder_traversal.py
+++ b/test/unit/scan/test_folder_traversal.py
@@ -78,7 +78,7 @@ class TestFolderTraversal:
         assert reporter.has_errors_or_warnings()
         assert isinstance(reporter.warnings, list)
         assert sorted(reporter.warnings) == [
-            f"WARNING: '{tmp_path}/dir/file\\\\bad.txt' path contains invalid name (file names must not contain '\\'). Skipping.",
+            f"WARNING: '{tmp_path}/dir/file\\bad.txt' path contains invalid name (file names must not contain '\\'). Skipping.",
             f"WARNING: '{tmp_path}/dir/file\\x7fbad.txt' path contains invalid name (file names must not contain DEL). Skipping.",
         ]
         reporter.close()
@@ -146,7 +146,7 @@ class TestFolderTraversal:
 
         assert reporter.has_errors_or_warnings()
         assert reporter.warnings == [
-            f"WARNING: '{tmp_path}/dir/dir\\\\bad' path contains invalid name (file names must not contain '\\'). Skipping."
+            f"WARNING: '{tmp_path}/dir/dir\\bad' path contains invalid name (file names must not contain '\\'). Skipping."
         ]
         reporter.close()
 

--- a/test/unit/scan/test_folder_traversal.py
+++ b/test/unit/scan/test_folder_traversal.py
@@ -88,10 +88,6 @@ class TestFolderTraversal:
             fix_windows_path_limit(str(tmp_path / "dir" / "subdir" / "file2.txt")),
         ]
 
-    @pytest.mark.skipif(
-        platform.system() in ('Windows', 'Darwin'),
-        reason="Windows and macOS have Unicode filesystems",
-    )
     def test_invalid_unicode_filename(self, tmp_path):
 
         # Create a directory structure below with initial scanning point at tmp_path/dir:

--- a/test/unit/scan/test_folder_traversal.py
+++ b/test/unit/scan/test_folder_traversal.py
@@ -22,7 +22,7 @@ from b2sdk._internal.utils import fix_windows_path_limit
 class TestFolderTraversal:
     def test_flat_folder(self, tmp_path):
 
-        # Create a directory structure below with initial scannig point at tmp_path/dir:
+        # Create a directory structure below with initial scanning point at tmp_path/dir:
         # tmp_path
         # └── dir
         #     ├── file1.txt
@@ -47,7 +47,7 @@ class TestFolderTraversal:
 
     def test_folder_with_subfolders(self, tmp_path):
 
-        # Create a directory structure below with initial scannig point at tmp_path:
+        # Create a directory structure below with initial scanning point at tmp_path:
         # tmp_path
         # ├── dir1
         # │   ├── file1.txt
@@ -83,7 +83,7 @@ class TestFolderTraversal:
     )
     def test_folder_with_symlink_to_file(self, tmp_path):
 
-        # Create a directory structure below with initial scannig point at tmp_path:
+        # Create a directory structure below with initial scanning point at tmp_path:
         # tmp_path
         # ├── dir
         # │   └── file.txt
@@ -114,7 +114,7 @@ class TestFolderTraversal:
     @pytest.mark.timeout(5)
     def test_folder_with_circular_symlink(self, tmp_path):
 
-        # Create a directory structure below with initial scannig point at tmp_path:
+        # Create a directory structure below with initial scanning point at tmp_path:
         # tmp_path
         # ├── dir
         # │   └── file.txt
@@ -142,7 +142,7 @@ class TestFolderTraversal:
     @pytest.mark.timeout(5)
     def test_folder_with_symlink_to_parent(self, tmp_path):
 
-        # Create a directory structure below with the scannig point at tmp_path/parent/child/:
+        # Create a directory structure below with the scanning point at tmp_path/parent/child/:
         #   tmp_path
         #   ├── parent
         #   │   ├── child

--- a/test/unit/utils/test_escape.py
+++ b/test/unit/utils/test_escape.py
@@ -7,6 +7,7 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+import pytest
 
 from b2sdk._internal.utils.escape import (
     escape_control_chars,
@@ -15,8 +16,12 @@ from b2sdk._internal.utils.escape import (
 )
 
 
-def test_unprintable_to_hex():
-    cases = [
+@pytest.mark.parametrize(
+    (
+        "input_", "expected_unprintable_to_hex", "expected_escape_control_chars",
+        "expected_substitute_control_chars"
+    ), [
+        ('', '', '', ('', False)),
         (' abc-z', ' abc-z', "' abc-z'", (' abc-z', False)),
         ('a\x7fb', 'a\\x7fb', "'a\\x7fb'", ('a�b', True)),
         ('a\x00b a\x9fb ', 'a\\x00b a\\x9fb ', "'a\\x00b a\\x9fb '", ('a�b a�b ', True)),
@@ -25,12 +30,36 @@ def test_unprintable_to_hex():
         (
             '\x1b[32mC\x1b[33mC\x1b[34mI', '\\x1b[32mC\\x1b[33mC\\x1b[34mI',
             "'\\x1b[32mC\\x1b[33mC\\x1b[34mI'", ('�[32mC�[33mC�[34mI', True)
-        )
+        ),
     ]
-    for (
-        s, expected_unprintable_to_hex, expected_escape_control_chars,
-        expected_substitute_control_chars
-    ) in cases:
-        assert unprintable_to_hex(s) == expected_unprintable_to_hex
-        assert escape_control_chars(s) == expected_escape_control_chars
-        assert substitute_control_chars(s) == expected_substitute_control_chars
+)
+def test_unprintable_to_hex(
+    input_, expected_unprintable_to_hex, expected_escape_control_chars,
+    expected_substitute_control_chars
+):
+    assert unprintable_to_hex(input_) == expected_unprintable_to_hex
+    assert escape_control_chars(input_) == expected_escape_control_chars
+    assert substitute_control_chars(input_) == expected_substitute_control_chars
+
+
+def test_unprintable_to_hex__none():
+    """
+    Test that unprintable_to_hex handles None.
+
+    This was unintentionally supported and is only kept for compatibility.
+    """
+    assert unprintable_to_hex(None) is None  # type: ignore
+
+
+def test_escape_control_chars__none():
+    """
+    Test that escape_control_chars handles None.
+
+    This was unintentionally supported and is only kept for compatibility.
+    """
+    assert escape_control_chars(None) is None  # type: ignore
+
+
+def test_substitute_control_chars__none():
+    with pytest.raises(TypeError):
+        substitute_control_chars(None)  # type: ignore


### PR DESCRIPTION
Report invalid filenames when syncing and skip them, instead of crashing.