### PR TITLE
fix: retry stream read errors in SimpleDownloader

### DIFF
--- a/b2sdk/_internal/file_version.py
+++ b/b2sdk/_internal/file_version.py
@@ -471,6 +471,10 @@ class DownloadVersion(BaseFileVersion):
             return None
         return parse_http_date(self.expires)
 
+    @property
+    def _should_be_decoded(self) -> bool:
+        return bool(self.content_encoding and self.api.api_config.decode_content)
+
     def as_dict(self) -> dict:
         result = super().as_dict()
         if self.cache_control is not None:

--- a/b2sdk/_internal/transfer/inbound/downloaded_file.py
+++ b/b2sdk/_internal/transfer/inbound/downloaded_file.py
@@ -170,29 +170,22 @@ class DownloadedFile:
         self.check_hash = check_hash
 
     def _validate_download(self, bytes_read, actual_sha1):
-        if (
-            self.download_version.content_encoding is not None
-            and self.download_version.api.api_config.decode_content
-        ):
-            return
-        if self.range_ is None:
-            if bytes_read != self.download_version.content_length:
-                raise TruncatedOutput(bytes_read, self.download_version.content_length)
+        desired_length = self.range_[1] - self.range_[0] + 1 if self.range_ is not None else self.download_version.content_length
+        if bytes_read != desired_length:
+            raise TruncatedOutput(bytes_read, desired_length)
 
-            if (
-                self.check_hash
-                and self.download_version.content_sha1 != 'none'
-                and actual_sha1 != self.download_version.content_sha1
-            ):
-                raise ChecksumMismatch(
-                    checksum_type='sha1',
-                    expected=self.download_version.content_sha1,
-                    actual=actual_sha1,
-                )
-        else:
-            desired_length = self.range_[1] - self.range_[0] + 1
-            if bytes_read != desired_length:
-                raise TruncatedOutput(bytes_read, desired_length)
+        if (
+            not self.download_version._should_be_decoded
+            and self.check_hash
+            and self.range_ is None
+            and self.download_version.content_sha1 != 'none'
+            and actual_sha1 != self.download_version.content_sha1
+        ):
+            raise ChecksumMismatch(
+                checksum_type='sha1',
+                expected=self.download_version.content_sha1,
+                actual=actual_sha1,
+            )
 
     def save(self, file: BinaryIO, allow_seeking: bool | None = None) -> None:
         """

--- a/b2sdk/_internal/transfer/inbound/downloaded_file.py
+++ b/b2sdk/_internal/transfer/inbound/downloaded_file.py
@@ -170,7 +170,11 @@ class DownloadedFile:
         self.check_hash = check_hash
 
     def _validate_download(self, bytes_read, actual_sha1):
-        desired_length = self.range_[1] - self.range_[0] + 1 if self.range_ is not None else self.download_version.content_length
+        desired_length = (
+            self.range_[1] - self.range_[0] + 1
+            if self.range_ is not None
+            else self.download_version.content_length
+        )
         if bytes_read != desired_length:
             raise TruncatedOutput(bytes_read, desired_length)
 

--- a/b2sdk/_internal/transfer/inbound/downloader/abstract.py
+++ b/b2sdk/_internal/transfer/inbound/downloader/abstract.py
@@ -118,8 +118,7 @@ class AbstractDownloader(metaclass=B2TraceMetaAbstract):
             return False
         if (
             not self.SUPPORTS_DECODE_CONTENT
-            and download_version.content_encoding
-            and download_version.api.api_config.decode_content
+            and download_version._should_be_decoded
         ):
             return False
         return True

--- a/b2sdk/_internal/transfer/inbound/downloader/abstract.py
+++ b/b2sdk/_internal/transfer/inbound/downloader/abstract.py
@@ -116,10 +116,7 @@ class AbstractDownloader(metaclass=B2TraceMetaAbstract):
         """
         if self.REQUIRES_SEEKING and not allow_seeking:
             return False
-        if (
-            not self.SUPPORTS_DECODE_CONTENT
-            and download_version._should_be_decoded
-        ):
+        if not self.SUPPORTS_DECODE_CONTENT and download_version._should_be_decoded:
             return False
         return True
 

--- a/b2sdk/_internal/transfer/inbound/downloader/simple.py
+++ b/b2sdk/_internal/transfer/inbound/downloader/simple.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 from io import IOBase
 
+from requests.exceptions import ChunkedEncodingError, ContentDecodingError
 from requests.models import Response
 
 from b2sdk._internal.encryption.setting import EncryptionSetting
@@ -43,10 +44,13 @@ class SimpleDownloader(AbstractDownloader):
         chunk_size = self._get_chunk_size(actual_size)
 
         decoded_bytes_read = 0
-        for data in response.iter_content(chunk_size=chunk_size):
-            file.write(data)
-            digest.update(data)
-            decoded_bytes_read += len(data)
+        try:
+            for data in response.iter_content(chunk_size=chunk_size):
+                file.write(data)
+                digest.update(data)
+                decoded_bytes_read += len(data)
+        except (ChunkedEncodingError, ContentDecodingError) as exc:
+            logger.debug('Stream read error during download, will retry if needed: %s', exc)
         bytes_read = response.raw.tell()
         response.close()
 
@@ -58,8 +62,7 @@ class SimpleDownloader(AbstractDownloader):
         # or something and the server closes connection, while neither tcp or http have a problem
         # with the truncated output, so we detect it here and try to continue
 
-        num_tries = 5  # this is hardcoded because we are going to replace the entire retry interface soon, so we'll avoid deprecation here and keep it private
-        retries_left = num_tries - 1
+        retries_left = 4  # this is hardcoded because we are going to replace the entire retry interface soon, so we'll avoid deprecation here and keep it private
         while retries_left and bytes_read < download_version.content_length:
             new_range = self._get_remote_range(
                 response,
@@ -79,12 +82,15 @@ class SimpleDownloader(AbstractDownloader):
                 new_range.as_tuple(),
                 encryption=encryption,
             ) as followup_response:
-                for data in followup_response.iter_content(
-                    chunk_size=self._get_chunk_size(actual_size)
-                ):
-                    file.write(data)
-                    digest.update(data)
-                    decoded_bytes_read += len(data)
+                try:
+                    for data in followup_response.iter_content(
+                        chunk_size=self._get_chunk_size(actual_size)
+                    ):
+                        file.write(data)
+                        digest.update(data)
+                        decoded_bytes_read += len(data)
+                except (ChunkedEncodingError, ContentDecodingError) as exc:
+                    logger.debug('Stream read error during download, will retry if needed: %s', exc)
                 bytes_read += followup_response.raw.tell()
             retries_left -= 1
         return bytes_read, digest.hexdigest()

--- a/b2sdk/_internal/transfer/inbound/downloader/simple.py
+++ b/b2sdk/_internal/transfer/inbound/downloader/simple.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from io import IOBase
 
-from requests.exceptions import ChunkedEncodingError, ContentDecodingError
+from requests.exceptions import ChunkedEncodingError, ConnectionError, ContentDecodingError
 from requests.models import Response
 
 from b2sdk._internal.encryption.setting import EncryptionSetting
@@ -49,7 +49,7 @@ class SimpleDownloader(AbstractDownloader):
                 file.write(data)
                 digest.update(data)
                 decoded_bytes_read += len(data)
-        except (ChunkedEncodingError, ContentDecodingError) as exc:
+        except (ChunkedEncodingError, ConnectionError, ContentDecodingError) as exc:
             logger.debug('Stream read error during download, will retry if needed: %s', exc)
         bytes_read = response.raw.tell()
         response.close()
@@ -89,7 +89,7 @@ class SimpleDownloader(AbstractDownloader):
                         file.write(data)
                         digest.update(data)
                         decoded_bytes_read += len(data)
-                except (ChunkedEncodingError, ContentDecodingError) as exc:
+                except (ChunkedEncodingError, ConnectionError, ContentDecodingError) as exc:
                     logger.debug('Stream read error during download, will retry if needed: %s', exc)
                 bytes_read += followup_response.raw.tell()
             retries_left -= 1

--- a/b2sdk/_internal/transfer/inbound/downloader/simple.py
+++ b/b2sdk/_internal/transfer/inbound/downloader/simple.py
@@ -42,6 +42,7 @@ class SimpleDownloader(AbstractDownloader):
             response.close()
             return 0, digest.hexdigest()
         chunk_size = self._get_chunk_size(actual_size)
+        should_be_decoded = download_version._should_be_decoded
 
         decoded_bytes_read = 0
         try:
@@ -50,6 +51,8 @@ class SimpleDownloader(AbstractDownloader):
                 digest.update(data)
                 decoded_bytes_read += len(data)
         except (ChunkedEncodingError, ConnectionError, ContentDecodingError) as exc:
+            if should_be_decoded:
+                raise  # cannot resume a partially decoded stream
             logger.debug('Stream read error during download, will retry if needed: %s', exc)
         bytes_read = response.raw.tell()
         response.close()
@@ -63,7 +66,9 @@ class SimpleDownloader(AbstractDownloader):
         # with the truncated output, so we detect it here and try to continue
 
         retries_left = 4  # this is hardcoded because we are going to replace the entire retry interface soon, so we'll avoid deprecation here and keep it private
-        while retries_left and bytes_read < download_version.content_length:
+        while (
+            bytes_read < download_version.content_length and not should_be_decoded and retries_left
+        ):
             new_range = self._get_remote_range(
                 response,
                 download_version,

--- a/b2sdk/_internal/transfer/inbound/downloader/simple.py
+++ b/b2sdk/_internal/transfer/inbound/downloader/simple.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 class SimpleDownloader(AbstractDownloader):
     REQUIRES_SEEKING = False
     SUPPORTS_DECODE_CONTENT = True
+    MAX_DOWNLOAD_ATTEMPTS = 5
 
     def _download(
         self,
@@ -44,12 +45,10 @@ class SimpleDownloader(AbstractDownloader):
         chunk_size = self._get_chunk_size(actual_size)
         should_be_decoded = download_version._should_be_decoded
 
-        decoded_bytes_read = 0
         try:
             for data in response.iter_content(chunk_size=chunk_size):
                 file.write(data)
                 digest.update(data)
-                decoded_bytes_read += len(data)
         except (ChunkedEncodingError, ConnectionError, ContentDecodingError) as exc:
             if should_be_decoded:
                 raise  # cannot resume a partially decoded stream
@@ -65,7 +64,7 @@ class SimpleDownloader(AbstractDownloader):
         # or something and the server closes connection, while neither tcp or http have a problem
         # with the truncated output, so we detect it here and try to continue
 
-        retries_left = 4  # this is hardcoded because we are going to replace the entire retry interface soon, so we'll avoid deprecation here and keep it private
+        retries_left = self.MAX_DOWNLOAD_ATTEMPTS - 1
         while (
             bytes_read < download_version.content_length and not should_be_decoded and retries_left
         ):
@@ -76,10 +75,9 @@ class SimpleDownloader(AbstractDownloader):
             # original response is not closed at this point yet, as another layer is responsible for closing it, so a new socket might be allocated,
             # but this is a very rare case and so it is not worth the optimization
             logger.debug(
-                're-download attempts remaining: %i, bytes read: %i (decoded: %i). Getting range %s now.',
+                're-download attempts remaining: %i, bytes read: %i. Getting range %s now.',
                 retries_left,
                 bytes_read,
-                decoded_bytes_read,
                 new_range,
             )
             with session.download_file_from_url(
@@ -93,7 +91,6 @@ class SimpleDownloader(AbstractDownloader):
                     ):
                         file.write(data)
                         digest.update(data)
-                        decoded_bytes_read += len(data)
                 except (ChunkedEncodingError, ConnectionError, ContentDecodingError) as exc:
                     logger.debug('Stream read error during download, will retry if needed: %s', exc)
                 bytes_read += followup_response.raw.tell()

--- a/b2sdk/v1/api.py
+++ b/b2sdk/v1/api.py
@@ -68,6 +68,7 @@ class B2Api(v2.B2Api):
             raw_api=raw_api,
             api_config=api_config,
         )
+        self.api_config = api_config
         self.file_version_factory = self.FILE_VERSION_FACTORY_CLASS(self)
         self.download_version_factory = self.DOWNLOAD_VERSION_FACTORY_CLASS(self)
         self.services = Services(

--- a/b2sdk/v1/api.py
+++ b/b2sdk/v1/api.py
@@ -68,7 +68,7 @@ class B2Api(v2.B2Api):
             raw_api=raw_api,
             api_config=api_config,
         )
-        self.api_config = api_config
+        self.api_config = self.session.api_config
         self.file_version_factory = self.FILE_VERSION_FACTORY_CLASS(self)
         self.download_version_factory = self.DOWNLOAD_VERSION_FACTORY_CLASS(self)
         self.services = Services(

--- a/b2sdk/v1/session.py
+++ b/b2sdk/v1/session.py
@@ -31,9 +31,8 @@ class B2Session(v2.B2Session):
                 'raw_api,api_config', 'Provide at most one of: raw_api, api_config'
             )
 
-        if api_config is None:
-            api_config = v2.DEFAULT_HTTP_API_CONFIG
-        super().__init__(account_info=account_info, cache=cache, api_config=api_config)
+        self.api_config = api_config or v2.DEFAULT_HTTP_API_CONFIG
+        super().__init__(account_info=account_info, cache=cache, api_config=self.api_config)
         if raw_api is not None:
             self.raw_api = raw_api
 

--- a/changelog.d/+read-error-retry.fixed.md
+++ b/changelog.d/+read-error-retry.fixed.md
@@ -1,0 +1,1 @@
+Retry stream read errors during download in `SimpleDownloader`.

--- a/changelog.d/+read-error-retry.fixed.md
+++ b/changelog.d/+read-error-retry.fixed.md
@@ -1,1 +1,5 @@
 Retry stream read errors during download in `SimpleDownloader`.
+
+Decoded downloads with `decode_content=True` now validate truncation; previously all post-download checks were skipped for decoded streams.
+
+Fix `b2sdk.v1.B2Api` not exposing `api_config`.

--- a/noxfile.py
+++ b/noxfile.py
@@ -210,7 +210,7 @@ def build(session):
             "'v2': pathlib.Path(v2.__file__).resolve(), "
             "'v3': pathlib.Path(v3.__file__).resolve()}; "
             'print(module_files); '
-            "assert all(not path.is_relative_to(source_root) for path in module_files.values()), "
+            'assert all(not path.is_relative_to(source_root) for path in module_files.values()), '
             "f'Imported modules from checkout: {module_files!r}'; "
             "assert all('site-packages' in path.parts for path in module_files.values()), "
             "f'Imported modules from an unexpected location: {module_files!r}'"

--- a/test/unit/internal/transfer/downloader/test_simple.py
+++ b/test/unit/internal/transfer/downloader/test_simple.py
@@ -164,9 +164,7 @@ def test_download_file__decoded_stream_stream_read_error_reraises(
     download_version.api.api_config.decode_content = True
 
     attempts = count(1)
-    mock_response.iter_content = _make_iter_content(
-        mock_response, attempts, 1, stream_error
-    )
+    mock_response.iter_content = _make_iter_content(mock_response, attempts, 1, stream_error)
 
     followup_calls = 0
     download_func = bucket.api.services.session.download_file_from_url
@@ -181,8 +179,6 @@ def test_download_file__decoded_stream_stream_read_error_reraises(
     bucket.api.services.session.download_file_from_url = download_func_mock
 
     with pytest.raises(type(stream_error)):
-        downloader.download(
-            output_file, mock_response, download_version, b2api.session
-        )
+        downloader.download(output_file, mock_response, download_version, b2api.session)
 
     assert followup_calls == 0

--- a/test/unit/internal/transfer/downloader/test_simple.py
+++ b/test/unit/internal/transfer/downloader/test_simple.py
@@ -16,9 +16,9 @@ from typing import Any
 
 import pytest
 from apiver_deps import B2Api, Bucket, DownloadVersion, SimpleDownloader
-from requests.exceptions import ChunkedEncodingError, ContentDecodingError
+from requests.exceptions import ChunkedEncodingError, ConnectionError, ContentDecodingError
 from requests.models import Response
-from urllib3.exceptions import DecodeError, IncompleteRead, ProtocolError
+from urllib3.exceptions import DecodeError, IncompleteRead, ProtocolError, ReadTimeoutError
 
 CHUNKED_ENCODING_ERROR = ChunkedEncodingError(
     ProtocolError(
@@ -29,6 +29,7 @@ CHUNKED_ENCODING_ERROR = ChunkedEncodingError(
 CONTENT_DECODING_ERROR = ContentDecodingError(
     DecodeError('Error -3 while decompressing data: incorrect header check')
 )
+CONNECTION_ERROR = ConnectionError(ReadTimeoutError(None, None, 'Read timed out.'))
 
 
 @pytest.fixture
@@ -72,7 +73,7 @@ def _make_iter_content(
     response: Response,
     attempts: Iterator[int],
     fail_count: int,
-    stream_error: ChunkedEncodingError | ContentDecodingError,
+    stream_error: ChunkedEncodingError | ConnectionError | ContentDecodingError,
 ) -> Callable[..., Iterator[bytes]]:
     def iter_content(chunk_size: int = 1, decode_unicode: bool = False) -> Iterator[bytes]:
         attempt = next(attempts)
@@ -95,6 +96,7 @@ def _make_iter_content(
     'stream_error',
     [
         pytest.param(CHUNKED_ENCODING_ERROR, id='ChunkedEncodingError'),
+        pytest.param(CONNECTION_ERROR, id='ConnectionError'),
         pytest.param(CONTENT_DECODING_ERROR, id='ContentDecodingError'),
     ],
 )
@@ -107,7 +109,7 @@ def test_download_file__stream_read_error(
     file_content: bytes,
     mock_download_response: tuple[Response, DownloadVersion],
     fail_count: int,
-    stream_error: ChunkedEncodingError | ContentDecodingError,
+    stream_error: ChunkedEncodingError | ConnectionError | ContentDecodingError,
 ) -> None:
     mock_response, download_version = mock_download_response
 

--- a/test/unit/internal/transfer/downloader/test_simple.py
+++ b/test/unit/internal/transfer/downloader/test_simple.py
@@ -136,3 +136,53 @@ def test_download_file__stream_read_error(
         assert output_file.getvalue() == file_content
     else:
         assert bytes_written == fail_count
+
+
+@pytest.mark.parametrize(
+    'stream_error',
+    [
+        pytest.param(CHUNKED_ENCODING_ERROR, id='ChunkedEncodingError'),
+        pytest.param(CONNECTION_ERROR, id='ConnectionError'),
+        pytest.param(CONTENT_DECODING_ERROR, id='ContentDecodingError'),
+    ],
+)
+def test_download_file__decoded_stream_stream_read_error_reraises(
+    b2api: B2Api,
+    bucket: Bucket,
+    downloader: SimpleDownloader,
+    output_file: BytesIO,
+    file_content: bytes,
+    mock_download_response: tuple[Response, DownloadVersion],
+    stream_error: ChunkedEncodingError | ConnectionError | ContentDecodingError,
+) -> None:
+    """
+    Test that a stream read error during a decoded stream download is re-raised and not retried
+    """
+
+    mock_response, download_version = mock_download_response
+    download_version.content_encoding = 'gzip'
+    download_version.api.api_config.decode_content = True
+
+    attempts = count(1)
+    mock_response.iter_content = _make_iter_content(
+        mock_response, attempts, 1, stream_error
+    )
+
+    followup_calls = 0
+    download_func = bucket.api.services.session.download_file_from_url
+
+    def download_func_mock(*args: Any, **kwargs: Any) -> Response:
+        nonlocal followup_calls
+        followup_calls += 1
+        response = download_func(*args, **kwargs).__enter__()
+        response.iter_content = _make_iter_content(response, attempts, 1, stream_error)
+        return response
+
+    bucket.api.services.session.download_file_from_url = download_func_mock
+
+    with pytest.raises(type(stream_error)):
+        downloader.download(
+            output_file, mock_response, download_version, b2api.session
+        )
+
+    assert followup_calls == 0

--- a/test/unit/internal/transfer/downloader/test_simple.py
+++ b/test/unit/internal/transfer/downloader/test_simple.py
@@ -1,0 +1,136 @@
+######################################################################
+#
+# File: test/unit/internal/transfer/downloader/test_simple.py
+#
+# Copyright 2026 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+import os
+from collections.abc import Callable, Iterator
+from io import BytesIO
+from itertools import count
+from types import ModuleType
+from typing import Any
+
+import pytest
+from apiver_deps import B2Api, Bucket, DownloadVersion, SimpleDownloader
+from requests.exceptions import ChunkedEncodingError, ContentDecodingError
+from requests.models import Response
+from urllib3.exceptions import DecodeError, IncompleteRead, ProtocolError
+
+CHUNKED_ENCODING_ERROR = ChunkedEncodingError(
+    ProtocolError(
+        'Connection broken: IncompleteRead(1 bytes read, 99 more expected)',
+        IncompleteRead(1, 99),
+    )
+)
+CONTENT_DECODING_ERROR = ContentDecodingError(
+    DecodeError('Error -3 while decompressing data: incorrect header check')
+)
+
+
+@pytest.fixture
+def file_size() -> int:
+    return 100
+
+
+@pytest.fixture
+def file_content(file_size: int) -> bytes:
+    return os.urandom(file_size)
+
+
+@pytest.fixture
+def mock_download_response(
+    apiver_module: ModuleType,
+    bucket: Bucket,
+    file_content: bytes,
+) -> tuple[Response, DownloadVersion]:
+    file_version = bucket.upload_bytes(file_content, f'dummy_file_{len(file_content)}.txt')
+
+    url = bucket.api.session.get_download_url_by_name(bucket.name, file_version.file_name)
+    response = bucket.api.services.session.download_file_from_url(url).__enter__()
+
+    return (
+        response,
+        apiver_module.DownloadVersionFactory(bucket.api).from_response_headers(response.headers),
+    )
+
+
+@pytest.fixture
+def output_file() -> BytesIO:
+    return BytesIO()
+
+
+@pytest.fixture
+def downloader(apiver_module: ModuleType) -> SimpleDownloader:
+    return apiver_module.SimpleDownloader(force_chunk_size=5)
+
+
+def _make_iter_content(
+    response: Response,
+    attempts: Iterator[int],
+    fail_count: int,
+    stream_error: ChunkedEncodingError | ContentDecodingError,
+) -> Callable[..., Iterator[bytes]]:
+    def iter_content(chunk_size: int = 1, decode_unicode: bool = False) -> Iterator[bytes]:
+        attempt = next(attempts)
+        chunk = response.raw.read(1)
+        if chunk:
+            yield chunk
+        if attempt <= fail_count:
+            raise stream_error
+        while True:
+            chunk = response.raw.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+    return iter_content
+
+
+@pytest.mark.parametrize('fail_count', [0, 1, 2, 4, 5])
+@pytest.mark.parametrize(
+    'stream_error',
+    [
+        pytest.param(CHUNKED_ENCODING_ERROR, id='ChunkedEncodingError'),
+        pytest.param(CONTENT_DECODING_ERROR, id='ContentDecodingError'),
+    ],
+)
+def test_download_file__stream_read_error(
+    b2api: B2Api,
+    bucket: Bucket,
+    downloader: SimpleDownloader,
+    output_file: BytesIO,
+    file_size: int,
+    file_content: bytes,
+    mock_download_response: tuple[Response, DownloadVersion],
+    fail_count: int,
+    stream_error: ChunkedEncodingError | ContentDecodingError,
+) -> None:
+    mock_response, download_version = mock_download_response
+
+    attempts = count(1)
+    mock_response.iter_content = _make_iter_content(
+        mock_response, attempts, fail_count, stream_error
+    )
+
+    download_func = bucket.api.services.session.download_file_from_url
+
+    def download_func_mock(*args: Any, **kwargs: Any) -> Response:
+        response = download_func(*args, **kwargs).__enter__()
+        response.iter_content = _make_iter_content(response, attempts, fail_count, stream_error)
+        return response
+
+    bucket.api.services.session.download_file_from_url = download_func_mock
+
+    bytes_written, _ = downloader.download(
+        output_file, mock_response, download_version, b2api.session
+    )
+
+    if fail_count < 5:
+        assert bytes_written == file_size
+        assert output_file.getvalue() == file_content
+    else:
+        assert bytes_written == fail_count

--- a/test/unit/internal/transfer/test_downloaded_file.py
+++ b/test/unit/internal/transfer/test_downloaded_file.py
@@ -63,3 +63,13 @@ def test_validate_download_hash_check(decode_content):
     else:
         with pytest.raises(ChecksumMismatch):
             downloaded_file._validate_download(100, 'wrong')
+
+
+@pytest.mark.parametrize('decode_content', [True, False])
+def test_validate_download_hash_check_skipped_for_range_download(decode_content):
+    downloaded_file = _generate_downloaded_file(
+        decode_content=decode_content,
+        range_=(10, 19),
+        check_hash=True,
+    )
+    downloaded_file._validate_download(10, 'wrong')

--- a/test/unit/internal/transfer/test_downloaded_file.py
+++ b/test/unit/internal/transfer/test_downloaded_file.py
@@ -1,0 +1,65 @@
+######################################################################
+#
+# File: test/unit/internal/transfer/test_downloaded_file.py
+#
+# Copyright 2026 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+from unittest.mock import Mock
+
+import pytest
+from apiver_deps import DownloadedFile
+from apiver_deps_exception import ChecksumMismatch, TruncatedOutput
+
+
+def _generate_downloaded_file(
+    *,
+    decode_content: bool,
+    content_length: int = 100,
+    content_sha1: str = 'abc',
+    range_: tuple[int, int] | None = None,
+    check_hash: bool = True,
+):
+    download_version = Mock()
+    download_version.content_encoding = 'gzip' if decode_content else None
+    download_version.content_length = content_length
+    download_version.content_sha1 = content_sha1
+    download_version.api.api_config.decode_content = decode_content
+    download_version._should_be_decoded = decode_content
+    return DownloadedFile(
+        download_version=download_version,
+        download_manager=Mock(),
+        range_=range_,
+        response=Mock(),
+        encryption=None,
+        progress_listener=Mock(),
+        check_hash=check_hash,
+    )
+
+
+@pytest.mark.parametrize('decode_content', [True, False])
+def test_validate_download_truncated_full_download(decode_content):
+    # range not set, length doesn't match
+    downloaded_file = _generate_downloaded_file(decode_content=decode_content)
+    with pytest.raises(TruncatedOutput):
+        downloaded_file._validate_download(99, 'abc')
+
+
+@pytest.mark.parametrize('decode_content', [True, False])
+def test_validate_download_truncated_range_download(decode_content):
+    # range set, length doesn't match
+    downloaded_file = _generate_downloaded_file(decode_content=decode_content, range_=(10, 19))
+    with pytest.raises(TruncatedOutput):
+        downloaded_file._validate_download(9, 'abc')
+
+
+@pytest.mark.parametrize('decode_content', [True, False])
+def test_validate_download_hash_check(decode_content):
+    downloaded_file = _generate_downloaded_file(decode_content=decode_content, check_hash=True)
+    if decode_content:
+        downloaded_file._validate_download(100, 'wrong')
+    else:
+        with pytest.raises(ChecksumMismatch):
+            downloaded_file._validate_download(100, 'wrong')

--- a/test/unit/v_all/test_api.py
+++ b/test/unit/v_all/test_api.py
@@ -21,6 +21,7 @@ from apiver_deps import (
     InMemoryAccountInfo,
     InMemoryCache,
     RawSimulator,
+    StubAccountInfo,
 )
 from apiver_deps_exception import BucketIdNotFound
 
@@ -35,6 +36,21 @@ class DummyA:
 class DummyB:
     def __init__(self, *args, **kwargs):
         pass
+
+
+def test_b2api_stores_api_config_when_specified():
+    api_config = B2HttpApiConfig(decode_content=True)
+    api = B2Api(StubAccountInfo(), api_config=api_config)
+    assert api.api_config is api_config
+    if apiver_deps.V <= 1:
+        assert api.api_config is api.session.api_config
+
+
+@pytest.mark.apiver(to_ver=1)
+def test_b2api_stores_api_config_when_not_specified():
+    api = B2Api(StubAccountInfo())
+    assert isinstance(api.api_config, B2HttpApiConfig)
+    assert api.api_config is api.session.api_config
 
 
 class TestServices:

--- a/test/unit/v_all/test_download_version.py
+++ b/test/unit/v_all/test_download_version.py
@@ -9,11 +9,11 @@
 ######################################################################
 import pytest
 from apiver_deps import (
+    EMPTY_RANGE,
+    SSE_NONE,
     B2Api,
     B2HttpApiConfig,
     DownloadVersion,
-    EMPTY_RANGE,
-    SSE_NONE,
     StubAccountInfo,
 )
 

--- a/test/unit/v_all/test_download_version.py
+++ b/test/unit/v_all/test_download_version.py
@@ -1,0 +1,69 @@
+######################################################################
+#
+# File: test/unit/v_all/test_download_version.py
+#
+# Copyright 2026 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+import pytest
+from apiver_deps import (
+    B2Api,
+    B2HttpApiConfig,
+    DownloadVersion,
+    EMPTY_RANGE,
+    SSE_NONE,
+    StubAccountInfo,
+)
+
+
+def _make_download_version(api, *, content_encoding):
+    return DownloadVersion(
+        api=api,
+        id_='file_id',
+        file_name='file_name',
+        size=100,
+        content_type='text/plain',
+        content_sha1='abc',
+        file_info={},
+        upload_timestamp=0,
+        server_side_encryption=SSE_NONE,
+        range_=EMPTY_RANGE,
+        content_disposition=None,
+        content_length=100,
+        content_language=None,
+        expires=None,
+        cache_control=None,
+        content_encoding=content_encoding,
+    )
+
+
+@pytest.mark.parametrize(
+    'content_encoding, decode_content, expected',
+    [
+        (None, False, False),
+        (None, True, False),
+        ('gzip', False, False),
+        ('gzip', True, True),
+    ],
+)
+def test_should_be_decoded(content_encoding, decode_content, expected):
+    api = B2Api(StubAccountInfo(), api_config=B2HttpApiConfig(decode_content=decode_content))
+    download_version = _make_download_version(api, content_encoding=content_encoding)
+    assert download_version._should_be_decoded is expected
+
+
+@pytest.mark.apiver(to_ver=1)
+@pytest.mark.parametrize(
+    'content_encoding, decode_content, expected',
+    [
+        (None, False, False),
+        ('gzip', True, True),
+    ],
+)
+def test_should_be_decoded_without_api_config_kwarg(content_encoding, decode_content, expected):
+    api = B2Api(StubAccountInfo())
+    api.api_config.decode_content = decode_content
+    download_version = _make_download_version(api, content_encoding=content_encoding)
+    assert download_version._should_be_decoded is expected


### PR DESCRIPTION
`SimpleDownloader` already had range-based retry logic for truncated downloads (e.g. when the server closes the connection mid-stream), but `ChunkedEncodingError` and `ContentDecodingError` raised during `iter_content` bypassed that path and failed the download immediately.

This PR catches those exceptions during both the initial read and follow-up range requests, logs them at debug level, and lets the existing retry loop resume from `response.raw.tell()`.