### PR TITLE
Retry tests on all 5xx errors

### DIFF
--- a/b2sdk/_internal/exception.py
+++ b/b2sdk/_internal/exception.py
@@ -433,6 +433,15 @@ class ServiceError(TransientErrorMixin, B2Error):
     Used for HTTP status codes 500 through 599.
     """
 
+    def __init__(self, status, code, message):
+        super().__init__()
+        self._status = status
+        self._code = code
+        self._message = message
+
+    def __str__(self):
+        return f'{self._status} {self._code} {self._message}'
+
 
 class CapExceeded(B2Error):
     def __str__(self):
@@ -744,5 +753,5 @@ def interpret_b2_error(
     elif status == 429:
         return TooManyRequests(retry_after_seconds=response_headers.get('retry-after'))
     elif 500 <= status < 600:
-        return ServiceError('%d %s %s' % (status, code, message))
+        return ServiceError(status, code, message)
     return UnknownError('%d %s %s' % (status, code, message))

--- a/b2sdk/_internal/testing/helpers/bucket_manager.py
+++ b/b2sdk/_internal/testing/helpers/bucket_manager.py
@@ -25,6 +25,7 @@ from b2sdk._internal.exception import (
     BucketIdNotFound,
     DuplicateBucketName,
     FileNotPresent,
+    ServiceError,
     TooManyRequests,
 )
 from b2sdk._internal.file_lock import NO_RETENTION_FILE_SETTING, LegalHold, RetentionMode
@@ -41,6 +42,11 @@ ONE_HOUR_MILLIS = 60 * 60 * 1000
 BUCKET_CLEANUP_PERIOD_MILLIS = timedelta(hours=3).total_seconds() * 1000
 
 logger = logging.getLogger(__name__)
+
+
+def _retry_bucket_test_operation(exc: BaseException) -> bool:
+    # Retry on TooManyRequests as well as all 5xx errors (covered by ServiceError)
+    return isinstance(exc, (TooManyRequests, ServiceError))
 
 
 class BucketManager:
@@ -83,7 +89,7 @@ class BucketManager:
         }
 
     @tenacity.retry(
-        retry=tenacity.retry_if_exception_type(TooManyRequests),
+        retry=tenacity.retry_if_exception(_retry_bucket_test_operation),
         wait=tenacity.wait_exponential(),
         stop=tenacity.stop_after_attempt(8),
     )
@@ -152,7 +158,7 @@ class BucketManager:
             print(bucket)
 
     @tenacity.retry(
-        retry=tenacity.retry_if_exception_type(TooManyRequests),
+        retry=tenacity.retry_if_exception(_retry_bucket_test_operation),
         wait=tenacity.wait_exponential(),
         stop=tenacity.stop_after_attempt(8),
     )

--- a/changelog.d/1232.changed.md
+++ b/changelog.d/1232.changed.md
@@ -1,0 +1,1 @@
+Retry integration tests automatically when they fail because of a transient HTTP 5xx from B2.

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -7,9 +7,42 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+from __future__ import annotations
+
 import pytest
+
+from b2sdk._internal.exception import ServiceError, TooManyRequests
+
+INTEGRATION_TEST_RETRY_COUNT = 4
 
 
 @pytest.fixture(scope='session', autouse=True)
 def auto_change_account_info_dir(change_account_info_dir):
     pass
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem):
+    testfunction = pyfuncitem.obj
+    funcargs = pyfuncitem.funcargs
+    testargs = {arg: funcargs[arg] for arg in pyfuncitem._fixtureinfo.argnames}
+
+    for attempt in range(INTEGRATION_TEST_RETRY_COUNT + 1):
+        try:
+            testfunction(**testargs)
+            return True
+        except ServiceError as exc:
+            # Retry on all 5xx errors, which ServiceError covers
+            if attempt >= INTEGRATION_TEST_RETRY_COUNT:
+                raise
+            print(
+                f'Retrying {pyfuncitem.nodeid} after transient service error {exc._status}:'
+                f' attempt {attempt + 1} of {INTEGRATION_TEST_RETRY_COUNT}'
+            )
+        except TooManyRequests:
+            if attempt >= INTEGRATION_TEST_RETRY_COUNT:
+                raise
+            print(
+                f'Retrying {pyfuncitem.nodeid} after transient too many requests:'
+                f' attempt {attempt + 1} of {INTEGRATION_TEST_RETRY_COUNT}'
+            )

--- a/test/integration/test_upload.py
+++ b/test/integration/test_upload.py
@@ -10,14 +10,26 @@
 from __future__ import annotations
 
 import io
+import logging
+import secrets
 
-from b2sdk._internal.b2http import B2Http
+from b2sdk._internal.b2http import B2Http, HttpCallback
 from b2sdk._internal.encryption.setting import EncryptionKey, EncryptionSetting
 from b2sdk._internal.encryption.types import EncryptionAlgorithm, EncryptionMode
+from b2sdk._internal.utils import hex_sha1_of_stream
 from b2sdk.v2 import B2RawHTTPApi
 from b2sdk.v3.testing import IntegrationTestBase
 
 from .test_raw_api import authorize_raw_api
+
+logger = logging.getLogger(__name__)
+
+
+class FailSomeUploads(HttpCallback):
+    def pre_request(self, method, url, headers):
+        if method == 'POST' and 'b2_upload_file' in url:
+            headers['X-Bz-Test-Mode'] = 'fail_some_uploads'
+            logger.info('Added X-Bz-Test-Mode=fail_some_uploads header to %s', url)
 
 
 class TestUnboundStreamUpload(IntegrationTestBase):
@@ -46,6 +58,34 @@ class TestUnboundStreamUpload(IntegrationTestBase):
 
 
 class TestUploadLargeFile(IntegrationTestBase):
+    def test_raw_upload_with_intermittent_failures(self):
+        bucket = self.create_bucket()
+        raw_api = self.b2_api.session.raw_api
+        b2_http = raw_api.b2_http
+        account_info = self.b2_api.account_info
+        callback = FailSomeUploads()
+        b2_http.add_callback(callback)
+        try:
+            payload = b'payload'
+            file_name = f'fail-some-uploads-{secrets.token_hex(4)}'
+            upload_url = raw_api.get_upload_url(
+                account_info.get_api_url(),
+                account_info.get_account_auth_token(),
+                bucket.id_,
+            )
+            raw_api.upload_file(
+                upload_url['uploadUrl'],
+                upload_url['authorizationToken'],
+                file_name,
+                len(payload),
+                'text/plain',
+                hex_sha1_of_stream(io.BytesIO(payload), len(payload)),
+                {},
+                io.BytesIO(payload),
+            )
+        finally:
+            b2_http.callbacks.remove(callback)
+
     def test_ssec_key_id(self):
         sse_c = EncryptionSetting(
             mode=EncryptionMode.SSE_C,

--- a/test/unit/test_exception.py
+++ b/test/unit/test_exception.py
@@ -159,6 +159,9 @@ class TestInterpretError:
     def test_service_error(self):
         error = interpret_b2_error(500, 'code', 'message', {})
         assert isinstance(error, ServiceError)
+        assert error._status == 500
+        assert error._code == 'code'
+        assert error._message == 'message'
         assert '500 code message' == str(error)
 
     def test_unknown_error(self):


### PR DESCRIPTION
> [!NOTE]
> This corresponds to the PR @ https://github.com/Backblaze/b2-sdk-python/pull/574 which Pawel made in the wrong repo

This PR verifies integration retry behavior against live B2 CI credentials.\n\nIt adds integration-test retries for transient B2 service errors and an upload test that uses the documented X-Bz-Test-Mode: fail_some_uploads hook.